### PR TITLE
Fix mobile wallet connect

### DIFF
--- a/src/mobx/stores/walletStore.ts
+++ b/src/mobx/stores/walletStore.ts
@@ -71,9 +71,7 @@ class WalletStore {
 
 	connect = action((wsOnboard: any) => {
 		let walletState = wsOnboard.getState();
-		console.log("Connecting: ", walletState)
 		this.setProvider(walletState.wallet.provider)
-		console.log('Connected: ', this.provider)
 		this.connectedAddress = walletState.address;
 		this.onboard = wsOnboard;
 	})


### PR DESCRIPTION
Use the walletState provided by onboard.js to determine the initial connected address rather than the provider which can deliver in different formats.