### PR TITLE
Fixed formatting issue for tokensBalance

### DIFF
--- a/src/components/Collection/Setts/DepositCard.tsx
+++ b/src/components/Collection/Setts/DepositCard.tsx
@@ -9,6 +9,7 @@ import { VaultSymbol } from '../../Common/VaultSymbol';
 import { UnfoldMoreTwoTone } from '@material-ui/icons';
 import useInterval from '@use-it/interval';
 import { Vault } from '../../../mobx/model';
+import BigNumber from 'bignumber.js';
 
 const useStyles = makeStyles((theme) => ({
 	border: {
@@ -48,7 +49,7 @@ interface DepositCardProps {
 	vault: Vault;
 	sett: any;
 	onOpen: any;
-	balance: number;
+	balance: string;
 	balanceValue: string;
 }
 
@@ -95,14 +96,6 @@ export const DepositCard = (props: DepositCardProps): React.ReactElement => {
 		return { apy: 0, tooltip: '' };
 	};
 	const { apy, tooltip } = getRoi();
-	const getTokens = (tokens: number) => {
-		if (tokens > 0 && tokens < 0.00001) {
-			// Visual 0 Balance
-			return '< 0.00001';
-		}
-		return formatWithCommas(tokens);
-	};
-	const tokenBalance = getTokens(balance);
 
 	return (
 		<>
@@ -125,7 +118,7 @@ export const DepositCard = (props: DepositCardProps): React.ReactElement => {
 				</Grid>
 				<Grid item xs={6} md={2}>
 					<Typography variant="body1" color={'textPrimary'}>
-						{tokenBalance}
+						{balance}
 					</Typography>
 				</Grid>
 				<Grid item className={classes.mobileLabel} xs={6}>

--- a/src/components/Collection/Setts/DepositList.tsx
+++ b/src/components/Collection/Setts/DepositList.tsx
@@ -60,7 +60,7 @@ export default function DepositList(props: DepositListProps): JSX.Element {
 						vault={vault}
 						sett={sett}
 						onOpen={onOpen}
-						balance={parseFloat(formatBalance(vault.underlyingToken))}
+						balance={formatBalance(vault.underlyingToken)}
 						balanceValue={formatTokenBalanceValue(vault.underlyingToken, currency)}
 					/>
 				</ListItem>
@@ -80,7 +80,7 @@ export default function DepositList(props: DepositListProps): JSX.Element {
 						vault={vault}
 						sett={sett}
 						onOpen={onOpen}
-						balance={parseFloat(formatBalanceUnderlying(vault))}
+						balance={formatBalanceUnderlying(vault)}
 						balanceValue={formatBalanceValue(vault, currency)}
 					/>
 				</ListItem>
@@ -101,7 +101,7 @@ export default function DepositList(props: DepositListProps): JSX.Element {
 						vault={vault}
 						sett={sett}
 						onOpen={onOpen}
-						balance={parseFloat(formatGeyserBalance(geyser))}
+						balance={formatGeyserBalance(geyser)}
 						balanceValue={formatGeyserBalanceValue(geyser, currency)}
 					/>
 				</ListItem>

--- a/src/mobx/reducers/statsReducers.ts
+++ b/src/mobx/reducers/statsReducers.ts
@@ -4,7 +4,7 @@ import { RootStore } from 'mobx/store';
 import deploy from 'config/deployments/mainnet.json';
 import Web3 from 'web3';
 
-import { inCurrency } from 'mobx/utils/helpers';
+import { inCurrency, formatTokens } from 'mobx/utils/helpers';
 import { getDiggPerShare } from 'mobx/utils/diggHelpers';
 import { rewards as rewardsConfig } from 'config/system/geysers';
 import {
@@ -186,18 +186,14 @@ export function formatSupply(token: Token): string {
 }
 
 export function formatBalance(token: Token): string {
-	if (token) return inCurrency(token.balance.dividedBy(10 ** token.decimals), 'eth', true, 5, true);
+	if (token) return formatTokens(token.balance.dividedBy(10 ** token.decimals));
 	else {
 		return '0.00';
 	}
 }
 export function formatGeyserBalance(geyser: Geyser): string {
-	return inCurrency(
+	return formatTokens(
 		geyser.balance.plus(geyser.vault.balance).multipliedBy(geyser.vault.pricePerShare).dividedBy(1e18),
-		'eth',
-		true,
-		5,
-		true,
 	);
 }
 export function formatGeyserHoldings(vault: Vault): string {
@@ -228,13 +224,7 @@ export function formatStaked(geyser: Geyser): string {
 }
 export function formatBalanceUnderlying(vault: Vault): string {
 	const ppfs = vault.symbol === 'bDIGG' ? getDiggPerShare(vault) : vault.pricePerShare;
-	return inCurrency(
-		vault.balance.multipliedBy(ppfs).dividedBy(10 ** vault.decimals),
-		'eth',
-		true,
-		vault.underlyingToken.decimals,
-		true,
-	);
+	return formatTokens(vault.balance.multipliedBy(ppfs).dividedBy(10 ** vault.decimals));
 }
 
 export function formatHoldingsValue(vault: Vault, currency: string): string {

--- a/src/mobx/utils/helpers.ts
+++ b/src/mobx/utils/helpers.ts
@@ -241,6 +241,20 @@ export const inCurrency = (
 	return `${prefix}${fixedNormal}${suffix}`;
 };
 
+export const formatTokens = (value: BigNumber): string => {
+	let decimals = 5;
+
+	if (!value || value.isNaN()) return '0.00';
+	else {
+		if (value.gt(0) && value.lt(10 ** -decimals)) {
+			return '< 0.00001';
+		} else if (value.dividedBy(1e4).gt(1)) {
+			decimals = 2;
+		}
+		return numberWithCommas(value.toFixed(decimals, BigNumber.ROUND_HALF_FLOOR));
+	}
+};
+
 export const numberWithCommas = (x: string): string => {
 	const parts = x.toString().split('.');
 	parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');


### PR DESCRIPTION
-Changed DepositCard to take formatted balance directly and display it
-Moved >0.0001 logic to new 'formatTokens()' function on helpers.ts
-Removed ParseFloat from DepositCard's balance prop
-Changed formatBalanceUnderlying(), formatBalance() and formatGeyserBalance() functions to use 'formatTokens()' instead of 'inCurrency()'
-Handled comma formatting within new formatTokens()