### PR TITLE
Removed double commas formatting from GeyserStake and VaultWithdraw

### DIFF
--- a/src/components/Collection/Forms/GeyserStake.tsx
+++ b/src/components/Collection/Forms/GeyserStake.tsx
@@ -8,7 +8,6 @@ import { Loader } from '../../Loader';
 import { BigNumber } from 'bignumber.js';
 import { useForm } from 'react-hook-form';
 import { formatBalanceUnderlying } from 'mobx/reducers/statsReducers';
-import { numberWithCommas } from 'mobx/utils/helpers';
 
 const TEXTFIELD_ID = 'amountField';
 
@@ -85,8 +84,7 @@ export const GeyserStake = observer((props: any) => {
 				>
 					<div>
 						<Typography variant="body2" color={'textSecondary'} style={{ marginBottom: '.2rem' }}>
-							Underlying {vault.underlyingToken.symbol}:{' '}
-							{numberWithCommas(formatBalanceUnderlying(vault))}
+							Underlying {vault.underlyingToken.symbol}: {formatBalanceUnderlying(vault)}
 						</Typography>
 						<Typography variant="body1" color={'textSecondary'} style={{ marginBottom: '.2rem' }}>
 							Available {vault.symbol}: {totalAvailable}

--- a/src/components/Collection/Forms/VaultWithdraw.tsx
+++ b/src/components/Collection/Forms/VaultWithdraw.tsx
@@ -9,7 +9,6 @@ import { Loader } from 'components/Loader';
 import { BigNumber } from 'bignumber.js';
 import { useForm } from 'react-hook-form';
 import { formatBalanceUnderlying } from 'mobx/reducers/statsReducers';
-import { numberWithCommas } from 'mobx/utils/helpers';
 
 const TEXTFIELD_ID = 'amountField';
 
@@ -86,8 +85,7 @@ export const VaultWithdraw = observer((props: any) => {
 				>
 					<div>
 						<Typography variant="body2" color={'textSecondary'} style={{ marginBottom: '.2rem' }}>
-							Underlying {vault.underlyingToken.symbol}:{' '}
-							{numberWithCommas(formatBalanceUnderlying(vault))}
+							Underlying {vault.underlyingToken.symbol}: {formatBalanceUnderlying(vault)}
 						</Typography>
 						<Typography variant="body1" color={'textSecondary'} style={{ marginBottom: '.2rem' }}>
 							Deposited {vault.symbol}: {totalAvailable}

--- a/src/components/Collection/Setts/DepositCard.tsx
+++ b/src/components/Collection/Setts/DepositCard.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState } from 'react';
-import { formatWithCommas } from 'mobx/utils/api';
 
 import { StoreContext } from '../../../mobx/store-context';
 import { Tooltip, IconButton, Grid, Chip } from '@material-ui/core';
@@ -9,7 +8,6 @@ import { VaultSymbol } from '../../Common/VaultSymbol';
 import { UnfoldMoreTwoTone } from '@material-ui/icons';
 import useInterval from '@use-it/interval';
 import { Vault } from '../../../mobx/model';
-import BigNumber from 'bignumber.js';
 
 const useStyles = makeStyles((theme) => ({
 	border: {

--- a/src/mobx/utils/helpers.ts
+++ b/src/mobx/utils/helpers.ts
@@ -244,7 +244,7 @@ export const inCurrency = (
 export const formatTokens = (value: BigNumber): string => {
 	let decimals = 5;
 
-	if (!value || value.isNaN()) return '0.00';
+	if (!value || value.isNaN()) return '0.00000';
 	else {
 		if (value.gt(0) && value.lt(10 ** -decimals)) {
 			return '< 0.00001';


### PR DESCRIPTION
-Removed the numberWithCommas method from GeyserStake and VaultWithdraw since this is now handled by the formatTokens method within formatBalanceUnderlying().
-Changed the default token amount at formatTokens() from 0.00 to 0.00000 to even the amount of decimals used.