### PR TITLE
use public cloudflare eth node

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,7 +4,8 @@ import { token as BADGER_ADDRESS, digg_system, sett_system } from './deployments
 export const INFURA_KEY = '32d16e34f8af476e9ef63b34ba2a16cc';
 export const APP_URL = 'https://app.badger.finance/';
 export const CONTACT_EMAIL = 'hello@badger.finance';
-export const RPC_URL = 'https://eth-mainnet.alchemyapi.io/v2/ZPhpI9buZLLAvjR44hryTAhiC5V-HueZ';
+export const RPC_URL = 'https://cloudflare-eth.com'
+// export const RPC_URL = 'https://eth-mainnet.alchemyapi.io/v2/ZPhpI9buZLLAvjR44hryTAhiC5V-HueZ';
 export const APP_NAME = 'badgerDAO';
 export const PORTIS_APP_ID = 'cbf7534d-170d-4903-943f-e607dc588b7f';
 


### PR DESCRIPTION
https://blog.cloudflare.com/cloudflare-ethereum-gateway/
how can we test this? i've had great experiences using this public free service - is there some way we can set this up and fallback to alchemy on issues?

I'm thinking this will be the last piece so save a lot of money on the app ui