### PR TITLE
Fix ETH ( Ξ ) symbol display on Digg, Portfolio and Badger Price

### DIFF
--- a/src/mobx/reducers/statsReducers.ts
+++ b/src/mobx/reducers/statsReducers.ts
@@ -258,7 +258,7 @@ export function formatBalanceValue(vault: Vault, currency: string): string {
 			.multipliedBy(diggMultiplier)
 			.dividedBy(10 ** vault.decimals),
 		currency,
-		true,
+		currency != 'eth',
 	);
 }
 
@@ -273,7 +273,7 @@ export function formatGeyserBalanceValue(geyser: Geyser, currency: string): stri
 			.plus(geyser.vault.balanceValue())
 			.dividedBy(10 ** geyser.vault.decimals),
 		currency,
-		true,
+		currency != 'eth',
 	);
 }
 


### PR DESCRIPTION
This PR introduces a fix for issue #329 - Fix ETH ( Ξ ) symbol display on Digg, Portfolio and Badger Price. 

Issue introduced by a hardcoded flag on `inCurrency()` within `formatPrice()` and `formatTokenBalanceValue()` at `statsReducers.ts`. The flag was hardcoded to hide the ETH symbol regardless of the currency. A condition was implemented to set the flag to true only when `currency` != 'eth'.

Result:
![image](https://user-images.githubusercontent.com/25463788/115472588-30f91380-a208-11eb-8af1-807482355aa9.png)
![image](https://user-images.githubusercontent.com/25463788/115472609-39e9e500-a208-11eb-8bc6-1470ac531643.png)

