### PR TITLE
Boost icon fix

### DIFF
--- a/src/components-v2/leaderboard/LeaderBoard.tsx
+++ b/src/components-v2/leaderboard/LeaderBoard.tsx
@@ -60,12 +60,12 @@ const useStyles = makeStyles((theme) => ({
 	icon: {
 		height: '20px',
 		width: '20px',
-		marginLeft: '-35px',
+		marginLeft: '-80px',
 		position: 'absolute',
 		[theme.breakpoints.down('sm')]: {
 			height: '15px',
 			width: '15px',
-			marginLeft: '-25px',
+			marginLeft: '-60px',
 		},
 	},
 	rankContainer: {


### PR DESCRIPTION
The margin for the saiyan boost icon was overlapping with the rank when it was >100.  This update moves the icon outside of the range of addresses <100,000