### PR TITLE
Fix: amount being removed on entering 0 as input value 

### DIFF
--- a/src/components/IbBTC/Mint.tsx
+++ b/src/components/IbBTC/Mint.tsx
@@ -137,7 +137,7 @@ export const Mint = observer(
 
 		const handleTokenChange = async (token: TokenModel): Promise<void> => {
 			setSelectedToken(token);
-			if (inputAmount) {
+			if (inputAmount?.displayValue) {
 				setInputAmount({
 					...inputAmount,
 					actualValue: token.scale(inputAmount.displayValue),
@@ -147,7 +147,7 @@ export const Mint = observer(
 		};
 
 		const handleMintClick = async (): Promise<void> => {
-			if (inputAmount) {
+			if (inputAmount?.actualValue && !inputAmount.actualValue.isNaN()) {
 				await store.ibBTCStore.mint(selectedToken, inputAmount.actualValue);
 				resetState();
 			}

--- a/src/components/IbBTC/Redeem.tsx
+++ b/src/components/IbBTC/Redeem.tsx
@@ -168,13 +168,13 @@ export const Redeem = observer((): any => {
 
 	const handleTokenChange = async (token: TokenModel): Promise<void> => {
 		setSelectedToken(token);
-		if (inputAmount) {
+		if (inputAmount?.actualValue && !inputAmount.actualValue.isNaN()) {
 			await calculateRedeem(inputAmount.actualValue, token);
 		}
 	};
 
 	const handleRedeemClick = async (): Promise<void> => {
-		if (inputAmount) {
+		if (inputAmount?.actualValue && !inputAmount.actualValue.isNaN()) {
 			await store.ibBTCStore.redeem(selectedToken, inputAmount.actualValue);
 			resetState();
 		}


### PR DESCRIPTION
### Summary 

This fix reverts the changes applied on https://github.com/Badger-Finance/v2-ui/pull/481.

The changes were incorrect and were causing that the input value was cleared if the input amount was zero. This issue can be reproduced by entering `0` as input value on both mint and redeem https://dev-app.badger.finance/ibBTC.

The original error is now properly solved by checking the `inputAmount` properties values rather than checking only if the object was defined.

