### PR TITLE
CI Build fixes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,4 +20,4 @@ jobs:
       - name: Run Tests
         run: yarn test
       - name: Test Build
-        run: yarn build
+        run: CI=false yarn build


### PR DESCRIPTION
Removed commitlint action and added flag to build command to disable the CI environment variable and allow build to complete with[ warnings.](https://stackoverflow.com/questions/62415804/how-to-prevent-netlify-from-treating-warnings-as-errors-because-process-env-ci)