### PR TITLE
feat: up gas limits for bcrvtbtc mints and enable option

### DIFF
--- a/src/components/Bridge/BridgeForm.tsx
+++ b/src/components/Bridge/BridgeForm.tsx
@@ -304,6 +304,12 @@ export const BridgeForm = observer(({ classes }: any) => {
 			contractFn: 'mint',
 			contractParams,
 		};
+		// NB: We explicitly set the gas limit for tbtc mints since estimateGas underestimates the gas needed.
+		if (token === 'bCRVtBTC') {
+			params.txConfig = {
+				gas: 1000000,
+			};
+		}
 
 		await begin({ params } as RenVMTransaction, () => {
 			resetState();
@@ -559,6 +565,13 @@ export const BridgeForm = observer(({ classes }: any) => {
 								<span>bCRVsBTC</span>
 							</span>
 						</MenuItem>
+
+						<MenuItem value={'bCRVtBTC'}>
+							<span className={classes.menuItem}>
+								<img src={crvBTCLogo} className={classes.logo} />
+								<span>bCRVtBTC</span>
+							</span>
+						</MenuItem>
 					</Select>
 				)}
 
@@ -607,6 +620,13 @@ export const BridgeForm = observer(({ classes }: any) => {
 							<span className={classes.menuItem}>
 								<img src={crvBTCLogo} className={classes.logo} />
 								<span>bCRVsBTC</span>
+							</span>
+						</MenuItem>
+
+						<MenuItem value={'bCRVtBTC'}>
+							<span className={classes.menuItem}>
+								<img src={crvBTCLogo} className={classes.logo} />
+								<span>bCRVtBTC</span>
 							</span>
 						</MenuItem>
 					</Select>


### PR DESCRIPTION
- ups gas limit to 1m (actual usage is between 650k - 800k)
- includes note on gas overestimation
- estimated gas displayed on the higher end at 800k