### PR TITLE
Fix lint scripts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
-yarn lint
+yarn lint-fix-warn

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"eject": "react-scripts eject",
 		"predeploy": "npm run build",
 		"deploy": "gh-pages -d build",
-		"lint": "eslint \"**/*.{js,jsx,json,ts,tsx}\" --fix --no-error-on-unmatched-pattern --ignore-pattern node_modules/ --ignore-pattern build/ --max-warnings=0",
+		"lint": "eslint \"**/*.{js,jsx,json,ts,tsx}\" --no-error-on-unmatched-pattern --ignore-pattern node_modules/ --ignore-pattern build/ --max-warnings=0",
 		"lint-fix": "yarn lint --quiet --fix",
 		"lint-fix-warn": "yarn lint --fix",
 		"ui": "yarn upgradeInteractive"


### PR DESCRIPTION
The lint scripts in package.json are not working for me (maybe I'm using them incorrectly). The precommit hook script though is working. So I moved that into package.json and had the precommit script use the package.json version.

Feel free to close if this does not make sense.