### PR TITLE
hotfix: changed redeem validator to use ibbtc

### DIFF
--- a/src/components/IbBTC/Redeem.tsx
+++ b/src/components/IbBTC/Redeem.tsx
@@ -177,7 +177,7 @@ export const Redeem = observer((): any => {
 
 	const handleRedeemClick = async (): Promise<void> => {
 		if (inputAmount?.actualValue && !inputAmount.actualValue.isNaN()) {
-			const isValidAmount = store.ibBTCStore.isValidAmount(selectedToken, inputAmount.actualValue);
+			const isValidAmount = store.ibBTCStore.isValidAmount(ibBTC, inputAmount.actualValue);
 			if (!isValidAmount) return;
 			await store.ibBTCStore.redeem(selectedToken, inputAmount.actualValue);
 			resetState();


### PR DESCRIPTION
This PR closes Issue #624.

`handleRedeemClick()` was calling `isValidAmount()` with the selected token as a parameter instead of ibBTC. Since this function compares the amount passed to the user's balance of the parameter token in order to confirm that the user holds enough to transact it ended up failing for users that had a selected token balance smaller than the ibBTC amount they wanted to redeem. 

This simple fix produces the required behavior.