### PR TITLE
release: hotfix guarded sett deposit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # v2 UI Changelog
 
+### Hotfix - 06/28/2021
+
+-   fixed an issue causing users to not be able to deposit into gaurded setts when their wallet balance exceeded the cap
+
 ### v2.8.0 - 06/23/2021
 
 -   introduced experimental vaults to the badger arcade

--- a/src/components/Collection/Forms/VaultDeposit.tsx
+++ b/src/components/Collection/Forms/VaultDeposit.tsx
@@ -44,14 +44,15 @@ export const VaultDeposit = observer((props: SettModalProps) => {
 	}
 
 	const userBalance = user.getBalance(ContractNamespace.Token, badgerSett);
+	const depositBalance = TokenBalance.fromBalance(userBalance, amount ?? '0');
 	const vaultCaps = user.vaultCaps[sett.vaultToken];
 
 	let canDeposit = !!amount;
 	if (canDeposit && vaultCaps) {
-		const vaultCanDeposit = vaultCaps.vaultCap.tokenBalance.gte(userBalance.tokenBalance);
-		const userCanDeposit =
-			vaultCaps.userCap.tokenBalance.gte(userBalance.tokenBalance) && userBalance.balance.gt(0);
-		canDeposit = vaultCanDeposit && userCanDeposit;
+		const vaultHasSpace = vaultCaps.vaultCap.tokenBalance.gte(depositBalance.tokenBalance);
+		const userHasSpace = vaultCaps.userCap.tokenBalance.gte(depositBalance.tokenBalance);
+		const userHasBalance = userBalance.tokenBalance.gte(depositBalance.tokenBalance);
+		canDeposit = vaultHasSpace && userHasSpace && userHasBalance;
 	}
 
 	const handlePercentageChange = (percent: number) => {
@@ -62,7 +63,6 @@ export const VaultDeposit = observer((props: SettModalProps) => {
 		if (!amount) {
 			return;
 		}
-		const depositBalance = TokenBalance.fromBalance(userBalance, amount);
 		await contracts.deposit(sett, badgerSett, userBalance, depositBalance);
 	};
 


### PR DESCRIPTION
### Hotfix - 06/28/2021

-   fixed an issue causing users to not be able to deposit into gaurded setts when their wallet balance exceeded the cap