### PR TITLE
feat: update balances on connected address change

### DIFF
--- a/src/mobx/stores/UserStore.ts
+++ b/src/mobx/stores/UserStore.ts
@@ -69,6 +69,7 @@ export default class UserStore {
 					this.loadBouncerProof(address);
 					this.loadAccountDetails(address, network.name);
 					this.loadClaimProof(address);
+					this.updateBalances(true);
 				}
 			}
 		});


### PR DESCRIPTION
As of now, ff the users change their connected address from one without assets to one with assets or viceversa their portfolio balances is not updated

This PR solves the issue by calling the `updateBalances` method whenever the `connectedAddress` changes.