### PR TITLE
chore: provider fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # v2 UI Changelog
 
+### Hotfix - 07/12/2021
+
+-   add refresh when connecting wallet to set provider correctly
+
 ### Hotfix - 07/11/2021
 
 -   update convex sett fees

--- a/src/mobx/stores/UserStore.ts
+++ b/src/mobx/stores/UserStore.ts
@@ -202,7 +202,7 @@ export default class UserStore {
 			if (!batchRequests || batchRequests.length === 0) {
 				return;
 			}
-
+			this.refresh();
 			const callResults: CallResult[] = await this.batchCall.execute(batchRequests);
 			if (DEBUG) {
 				console.log({ network: network.name, callResults });

--- a/src/mobx/utils/helpers.ts
+++ b/src/mobx/utils/helpers.ts
@@ -375,7 +375,7 @@ export const fetchData = async <T>(
 
 // Reason: blocknative does not type their provider, must be any
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const getNetworkFromProvider = (provider: any): string | undefined => {
+export const getNetworkFromProvider = (provider?: any): string | undefined => {
 	return provider ? getNetworkNameFromId(parseInt(new BigNumber(provider.chainId, 16).toString(10))) : undefined;
 };
 


### PR DESCRIPTION
closes #688 and #691 

Provider was not being refreshed when connecting wallet so the app would be using a stale provider causing many downstream issues.