### PR TITLE
feat: Darken Sidebar collapsible items

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -178,6 +178,7 @@ export const Sidebar = observer(() => {
 		return clsx(isActive ? classes.activeListItem : listClass, ...additionalClasses);
 	};
 
+	// TODO: Deprecate this in favor of router integration https://github.com/Badger-Finance/v2-ui/issues/709
 	const getCollapsableItemClasses = (
 		collapseKey: string,
 		childrenRoutes: string[],


### PR DESCRIPTION
Darken collapsible items when they're not collapse but one of its child items is the active route.

Resolves #705.

Before:

https://user-images.githubusercontent.com/38574891/125682637-52e17051-28a9-4098-952e-bd241dae17d8.mp4

After:

https://user-images.githubusercontent.com/38574891/125682544-7020bf7f-410e-46bd-b819-3067deef522a.mp4

