### PR TITLE
chore: update digg oracle slots

### DIFF
--- a/src/config/system/rebase.ts
+++ b/src/config/system/rebase.ts
@@ -39,31 +39,19 @@ export const getRebase = (network: string): RebaseNetworkConfig | undefined => {
 						readMethods: [
 							{
 								name: 'providerReports',
-								args: [digg_system.centralizedOracle, 0],
-							},
-						],
-					},
-					{
-						addresses: [digg_system.marketMedianOracle],
-						abi: MedianOracle.abi as AbiItem[],
-						groupByNamespace: true,
-						namespace: 'oracle',
-						readMethods: [
-							{
-								name: 'providerReports',
-								args: [digg_system.centralizedOracle, 1],
-							},
-						],
-					},
-					{
-						addresses: [digg_system.marketMedianOracle],
-						abi: MedianOracle.abi as AbiItem[],
-						groupByNamespace: true,
-						namespace: 'oracle',
-						readMethods: [
-							{
-								name: 'providerReports',
 								args: [digg_system.newCentralizedOracle, 0],
+							},
+						],
+					},
+					{
+						addresses: [digg_system.marketMedianOracle],
+						abi: MedianOracle.abi as AbiItem[],
+						groupByNamespace: true,
+						namespace: 'oracle',
+						readMethods: [
+							{
+								name: 'providerReports',
+								args: [digg_system.newCentralizedOracle, 1],
 							},
 						],
 					},


### PR DESCRIPTION
the new oracle has 2 slots which rotate "correct" rates, the rebase had only the 1 for the new oracle. so it removes the old oracle and adds the second rotating slot for the new oracle report
