### PR TITLE
fix: fee multiplier issue

### DIFF
--- a/src/components-v2/common/dialogs/SettWithdraw.tsx
+++ b/src/components-v2/common/dialogs/SettWithdraw.tsx
@@ -54,10 +54,6 @@ export const SettWithdraw = observer(({ open = false, sett, badgerSett, onClose 
 	const userBalance = user.getBalance(ContractNamespace.Sett, badgerSett);
 	const vaultSymbol = setts.getToken(badgerSett.vaultToken.address)?.symbol || sett.asset;
 
-	const underlying = userBalance.tokenBalance.multipliedBy(sett.ppfs);
-	const underlyingBalance = new TokenBalance(userBalance.token, underlying, userBalance.price);
-	const underlyingSymbol = setts.getToken(badgerSett.depositToken.address)?.symbol || sett.asset;
-
 	const isLoading = contracts.settsBeingWithdrawn[sett.vaultToken];
 	const canWithdraw = !!connectedAddress && !!amount && userBalance.balance.gt(0);
 
@@ -88,9 +84,6 @@ export const SettWithdraw = observer(({ open = false, sett, badgerSett, onClose 
 			<SettDialogContent dividers className={classes.content}>
 				<Grid container alignItems="center">
 					<Grid item xs={12} sm={6}>
-						<Typography variant="body2" color="textSecondary">
-							{`Underlying ${underlyingSymbol}: ${underlyingBalance.balanceDisplay()}`}
-						</Typography>
 						<Typography variant="body1" color="textSecondary">
 							{`Deposited ${vaultSymbol}: ${userBalance.balanceDisplay()}`}
 						</Typography>

--- a/src/components-v2/common/dialogs/SettWithdrawFee.tsx
+++ b/src/components-v2/common/dialogs/SettWithdrawFee.tsx
@@ -42,7 +42,7 @@ export const SettWithdrawFee = observer(
 		const depositTokenDecimals = depositToken?.decimals || 18;
 
 		const withdrawAmount = new BigNumber(amount).multipliedBy(sett.ppfs);
-		const withdrawalFee = fee.div(100).multipliedBy(withdrawAmount);
+		const withdrawalFee = fee.div(1000).multipliedBy(withdrawAmount);
 		const amountAfterFee = new BigNumber(withdrawAmount).minus(withdrawalFee);
 
 		return (

--- a/src/components-v2/sett-detail/description/ApyComparisonBadge.tsx
+++ b/src/components-v2/sett-detail/description/ApyComparisonBadge.tsx
@@ -43,7 +43,7 @@ export enum ComparisonMode {
 	neutral = 'neutral',
 }
 
-export const ApyComparisonBadge = ({ apyComparison, mode }: Props): JSX.Element => {
+export default function ApyDisplayBadge({ apyComparison, mode }: Props): JSX.Element {
 	const classes = useStyles();
 
 	const badgeStylesByMode = {
@@ -64,4 +64,4 @@ export const ApyComparisonBadge = ({ apyComparison, mode }: Props): JSX.Element 
 			<span className={classes.apyText}>{apyComparison}</span>
 		</Typography>
 	);
-};
+}

--- a/src/mobx/model/rewards/performance.ts
+++ b/src/mobx/model/rewards/performance.ts
@@ -1,6 +1,15 @@
 export type Performance = {
-	oneDay?: number;
-	threeDay?: number;
-	sevenDay?: number;
-	thirtyDay?: number;
+	oneDay: number;
+	threeDay: number;
+	sevenDay: number;
+	thirtyDay: number;
 };
+
+export function scalePerformance(performance: Performance, scalar: number): Performance {
+	return {
+		oneDay: performance.oneDay * scalar,
+		threeDay: performance.threeDay * scalar,
+		sevenDay: performance.sevenDay * scalar,
+		thirtyDay: performance.thirtyDay * scalar,
+	};
+}

--- a/src/tests/__snapshots__/SettDeposit.test.tsx.snap
+++ b/src/tests/__snapshots__/SettDeposit.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`Sett Deposit can go back from full fees descriptions  1`] = `
                 pattern="^[0-9]*[.,]?[0-9]*$"
                 placeholder="Type an amount to deposit"
                 spellcheck="false"
+                style="text-align: right;"
                 type="text"
                 value=""
               />
@@ -564,6 +565,7 @@ exports[`Sett Deposit displays sett information 1`] = `
                 pattern="^[0-9]*[.,]?[0-9]*$"
                 placeholder="Type an amount to deposit"
                 spellcheck="false"
+                style="text-align: right;"
                 type="text"
                 value=""
               />

--- a/src/tests/__snapshots__/SettWithdraw.test.tsx.snap
+++ b/src/tests/__snapshots__/SettWithdraw.test.tsx.snap
@@ -80,11 +80,6 @@ exports[`Sett Withdraw displays sett information 1`] = `
               class="MuiGrid-root-85 MuiGrid-item-87 MuiGrid-grid-xs-12-131 MuiGrid-grid-sm-6-139"
             >
               <p
-                class="MuiTypography-root-55 MuiTypography-body2-56 MuiTypography-colorTextSecondary-81"
-              >
-                Underlying sBTCCRV: 0.000000000000000000
-              </p>
-              <p
                 class="MuiTypography-root-55 MuiTypography-body1-57 MuiTypography-colorTextSecondary-81"
               >
                 Deposited sBTCCRV: 0.000000000000000000
@@ -180,6 +175,7 @@ exports[`Sett Withdraw displays sett information 1`] = `
                 pattern="^[0-9]*[.,]?[0-9]*$"
                 placeholder="Type an amount to deposit"
                 spellcheck="false"
+                style="text-align: right;"
                 type="text"
                 value=""
               />

--- a/src/tests/ibBTC/__snapshots__/Mint.test.tsx.snap
+++ b/src/tests/ibBTC/__snapshots__/Mint.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`ibBTC Mint can apply max balance 1`] = `
             pattern="^[0-9]*[.,]?[0-9]*$"
             placeholder="0.000"
             spellcheck="false"
+            style="text-align: right;"
             type="text"
             value="5.000000"
           />

--- a/src/tests/ibBTC/__snapshots__/Redeem.test.tsx.snap
+++ b/src/tests/ibBTC/__snapshots__/Redeem.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`ibBTC Redeem can apply max balance 1`] = `
             pattern="^[0-9]*[.,]?[0-9]*$"
             placeholder="0.000"
             spellcheck="false"
+            style="text-align: right;"
             type="text"
             value="5.000000000000000000"
           />

--- a/src/tests/sett-details/__snapshots__/Description.test.tsx.snap
+++ b/src/tests/sett-details/__snapshots__/Description.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Description displays sett description 1`] = `
             renBTC/wBTC/sBTC
           </p>
           <p
-            class="MuiTypography-root-112 makeStyles-apyBadge-142 makeStyles-reducedApy-145 MuiTypography-body1-114"
+            class="MuiTypography-root-112 makeStyles-apyBadge-142 makeStyles-increasedApy-144 MuiTypography-body1-114"
           >
             <svg
               aria-hidden="true"
@@ -38,13 +38,13 @@ exports[`Description displays sett description 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M16 18l2.29-2.29-4.88-4.88-4 4L2 7.41 3.41 6l6 6 4-4 6.3 6.29L22 12v6z"
+                d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"
               />
             </svg>
             <span
               class="makeStyles-apyText-143"
             >
-              0.26%
+              2.14%
             </span>
           </p>
           <div
@@ -56,13 +56,13 @@ exports[`Description displays sett description 1`] = `
               role="button"
               tabindex="0"
             >
-              1 DAY
+              1 WEEK
             </div>
             <input
               aria-hidden="true"
               class="MuiSelect-nativeInput-168"
               tabindex="-1"
-              value="oneDay"
+              value="sevenDay"
             />
             <svg
               aria-hidden="true"

--- a/src/utils/useNumericInput.ts
+++ b/src/utils/useNumericInput.ts
@@ -1,5 +1,6 @@
 import { SetStateAction, ChangeEvent } from 'react';
 import { InputProps } from '@material-ui/core';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
 /**
  * Functions that will be triggered on valid changes
  */
@@ -19,6 +20,7 @@ interface NumericInputProps {
 		pattern: HTMLInputElement['pattern'];
 		spellCheck: HTMLInputElement['spellcheck'];
 		type: HTMLInputElement['type'];
+		style: CSSProperties;
 	};
 	onValidChange: (onChange: ChangeHandler) => (event: ChangeEvent<{ value: unknown }>) => void;
 }
@@ -54,6 +56,9 @@ export const useNumericInput = (): NumericInputProps => {
 			minLength: 1,
 			maxLength: 79,
 			spellCheck: false,
+			style: {
+				textAlign: 'right',
+			},
 		},
 		onValidChange,
 	};


### PR DESCRIPTION
few changes in this pr

- fix fee divisor to 1000 vs. 100 (showing - 5% vs. 0.5% fees)
- remove performance differential apr display in favor of more intuitive sampled apr (can revisit this later)
- slight ux changes to withdraw modal