### PR TITLE
fix: added mstable strategies details and placeholders

### DIFF
--- a/src/config/system/strategies.ts
+++ b/src/config/system/strategies.ts
@@ -322,6 +322,24 @@ export const getStrategies = (network?: string | null): StrategyNetworkConfig =>
 					strategyLink:
 						'https://badgerwiki.notion.site/Strategies-7bf5b27a451242538f02855ca5aaf4e4#1346adfaad7946eebd29a17fb4f6e8b7',
 				},
+				[deploy.sett_system.vaults['native.imBtc']]: {
+					name: '',
+					address: deploy.sett_system.strategies['native.imBtc'],
+					fees: {
+						['DAO Performance Fee']: new BigNumber(1000),
+						['Withdraw Fee']: new BigNumber(75),
+					},
+					strategyLink: 'https://badgerwiki.notion.site/placeholder',
+				},
+				[deploy.sett_system.vaults['native.fPmBtcHBtc']]: {
+					name: '',
+					address: deploy.sett_system.strategies['native.fPmBtcHBtc'],
+					fees: {
+						['DAO Performance Fee']: new BigNumber(1000),
+						['Withdraw Fee']: new BigNumber(75),
+					},
+					strategyLink: 'https://badgerwiki.notion.site/placeholder',
+				},
 			};
 	}
 };


### PR DESCRIPTION
This PR closes issue #884 

Addition of strategy information for the mStable strats on the `strategies.ts` config file. This fixes the bug of the app crashing when clicking on either of the mStable setts on dev-app.

NOTE: Fees and Links will need to be updated once defined. 