### PR TITLE
fix: pass multiplier as prop

### DIFF
--- a/src/components-v2/landing/SettListItem.tsx
+++ b/src/components-v2/landing/SettListItem.tsx
@@ -110,7 +110,7 @@ const SettListItem = observer(
 							</Typography>
 						</Grid>
 						<Grid item xs={6} md>
-							<SettItemApr sett={sett} divisor={isDisabled ? 1 : divisor} />
+							<SettItemApr sett={sett} divisor={isDisabled ? 1 : divisor} multiplier={multiplier} />
 							{multiplier !== undefined && (
 								<SettItemUserApr sett={sett} divisor={divisor} multiplier={multiplier} />
 							)}


### PR DESCRIPTION
solves #915. multiplier was not being passes as prop so it always defaulted to 1