### PR TITLE
fix: sett charts not displayed in mobile views

### DIFF
--- a/src/components-v2/sett-detail/MainContent.tsx
+++ b/src/components-v2/sett-detail/MainContent.tsx
@@ -27,6 +27,11 @@ const useStyles = makeStyles((theme) => ({
 		fontSize: 24,
 		fontWeight: 500,
 	},
+	chartsContainer: {
+		[theme.breakpoints.down('sm')]: {
+			minHeight: 600,
+		},
+	},
 }));
 
 interface Props {
@@ -61,7 +66,7 @@ export const MainContent = observer(
 					<Grid item xs={12} md={4} lg={3}>
 						<SpecsCard sett={sett} badgerSett={badgerSett} />
 					</Grid>
-					<Grid item xs={12} md={8} lg={9}>
+					<Grid item xs={12} md={8} lg={9} className={classes.chartsContainer}>
 						<ChartsCard sett={sett} />
 					</Grid>
 				</Grid>

--- a/src/components-v2/sett-detail/charts/BoostChart.tsx
+++ b/src/components-v2/sett-detail/charts/BoostChart.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { fitWidth } from 'react-stockcharts/lib/helper';
 import { format } from 'd3-format';
 import BaseAreaChart from './BaseAreaChart';
 import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
@@ -42,45 +41,37 @@ const BoostTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameTy
 
 interface Props {
 	sett: Sett;
-	width: number;
 }
 
-// the packages core fitWidth HOC does not support function components
-// see: https://github.com/rrag/react-stockcharts/issues/370#issuecomment-336439030
-class RawChartClass extends React.Component<Props> {
-	render() {
-		const { width, sett } = this.props;
-		const { sources, apr, minApr, maxApr } = sett;
+export const BoostChart = ({ sett }: Props): JSX.Element | null => {
+	const { sources, apr, minApr, maxApr } = sett;
 
-		if (!minApr || !maxApr) {
-			return null;
-		}
-
-		const boostableApr = sources
-			.filter((s) => s.boostable)
-			.map((s) => s.apr)
-			.reduce((total, apr) => (total += apr), 0);
-		const baseApr = apr - boostableApr;
-		const aprRange = maxApr - minApr;
-		const boostData = boostCheckpoints.map((checkpoint) => {
-			const rangeScalar = checkpoint / MAX_BOOST_LEVEL.multiplier;
-			return {
-				x: checkpoint,
-				y: (baseApr + rangeScalar * aprRange) / 100,
-			};
-		});
-
-		return (
-			<BaseAreaChart
-				title={'Badger Boost APR'}
-				data={boostData}
-				yFormatter={yScaleFormatter}
-				width={width}
-				customTooltip={<BoostTooltip />}
-				references={[{ value: apr / 100, label: `Baseline APR (${apr.toFixed(2)}%)` }]}
-			/>
-		);
+	if (!minApr || !maxApr) {
+		return null;
 	}
-}
 
-export const BoostChart = fitWidth(RawChartClass);
+	const boostableApr = sources
+		.filter((s) => s.boostable)
+		.map((s) => s.apr)
+		.reduce((total, apr) => (total += apr), 0);
+	const baseApr = apr - boostableApr;
+	const aprRange = maxApr - minApr;
+	const boostData = boostCheckpoints.map((checkpoint) => {
+		const rangeScalar = checkpoint / MAX_BOOST_LEVEL.multiplier;
+		return {
+			x: checkpoint,
+			y: (baseApr + rangeScalar * aprRange) / 100,
+		};
+	});
+
+	return (
+		<BaseAreaChart
+			title={'Badger Boost APR'}
+			data={boostData}
+			yFormatter={yScaleFormatter}
+			width="99%" // needs to be 99% see https://github.com/recharts/recharts/issues/172#issuecomment-307858843
+			customTooltip={<BoostTooltip />}
+			references={[{ value: apr / 100, label: `Baseline APR (${apr.toFixed(2)}%)` }]}
+		/>
+	);
+};

--- a/src/components-v2/sett-detail/charts/SettChart.tsx
+++ b/src/components-v2/sett-detail/charts/SettChart.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { fitWidth } from 'react-stockcharts/lib/helper';
 import { timeFormat } from 'd3-time-format';
 import { format } from 'd3-format';
 import { ChartMode, SettChartTimeframe } from '../../../mobx/model/setts/sett-charts';
@@ -10,35 +9,32 @@ import { ChartDataPoint } from 'mobx/model/charts/chart-data-point';
 interface Props {
 	mode: ChartMode;
 	timeframe: SettChartTimeframe;
-	data: ChartDataPoint[];
-	width: number;
+	data: ChartDataPoint[] | null;
 }
 
-// the packages core fitWidth HOC does not support function components
-// see: https://github.com/rrag/react-stockcharts/issues/370#issuecomment-336439030
-class RawChartClass extends React.Component<Props> {
-	render() {
-		const { width, timeframe, data, mode } = this.props;
+export const SettChart = (props: Props): JSX.Element | null => {
+	const { timeframe, data, mode } = props;
 
-		const yScaleFormatterByMode: Record<string, (val: number) => string> = {
-			[ChartMode.Value]: format('^$.3s'),
-			[ChartMode.Ratio]: format('^.5f'),
-			[ChartMode.AccountBalance]: format('^$.3s'),
-		};
-
-		const xSxcaleFormatter = timeframe === SettChartTimeframe.Day ? timeFormat('%H:%M') : timeFormat('%m-%d');
-		const yScaleFormatter = yScaleFormatterByMode[mode];
-		return (
-			<BaseAreaChart
-				title={ChartModeTitles[mode]}
-				data={data}
-				xFormatter={xSxcaleFormatter}
-				yFormatter={yScaleFormatter}
-				tooltipFormatter={timeFormat('%B %d, %Y')}
-				width={width}
-			/>
-		);
+	if (!data) {
+		return null;
 	}
-}
 
-export const SettChart = fitWidth(RawChartClass);
+	const yScaleFormatterByMode: Record<string, (val: number) => string> = {
+		[ChartMode.Value]: format('^$.3s'),
+		[ChartMode.Ratio]: format('^.5f'),
+		[ChartMode.AccountBalance]: format('^$.3s'),
+	};
+
+	const xSxcaleFormatter = timeframe === SettChartTimeframe.Day ? timeFormat('%H:%M') : timeFormat('%m-%d');
+	const yScaleFormatter = yScaleFormatterByMode[mode];
+	return (
+		<BaseAreaChart
+			title={ChartModeTitles[mode]}
+			data={data}
+			xFormatter={xSxcaleFormatter}
+			yFormatter={yScaleFormatter}
+			tooltipFormatter={timeFormat('%B %d, %Y')}
+			width="99%" // needs to be 99% see https://github.com/recharts/recharts/issues/172#issuecomment-307858843
+		/>
+	);
+};

--- a/src/components/Digg/AreaChart.tsx
+++ b/src/components/Digg/AreaChart.tsx
@@ -14,6 +14,7 @@ import { scaleTime } from 'd3-scale';
 
 const canvasGradient = createVerticalLinearGradient([{ stop: 0, color: hexToRGBA('#F2A52B', 0.0) }]);
 
+// TODO: deprecate react-stockcharts in favor of recharts
 function AreaChart(props: any) {
 	const gradientId = 'gradient-' + Math.floor(Math.random() * 100);
 


### PR DESCRIPTION
Solves #1192 

This one was tricky.

The charts were not displayed because unlike desktop view where the height of the charts section container is defined by the height of the sett detail column, in mobile, the card is standalone and needs to have a min-height so that the `<ResponsiveContainer />` can be displayed.

With the migration to Recharts the usage of the `fitWidth()` HOC is no longer required, responsiveness is now the responsibility of the `<ResponsiveContainer />`. 

That being said, for some reason, the container does not scale from large size to smaller ones. This is reported in this issue https://github.com/recharts/recharts/issues/172, the "hack" is to set it to "99%" instead of "100%" https://github.com/recharts/recharts/issues/172#issuecomment-307858843.