### PR TITLE
refactor: separate sett slugs by network

### DIFF
--- a/src/mobx/model/setts/slug-cache.ts
+++ b/src/mobx/model/setts/slug-cache.ts
@@ -1,0 +1,3 @@
+export interface SlugCache {
+	[chain: string]: Record<string, string>;
+}

--- a/src/mobx/stores/lockedCvxDelegationStore.ts
+++ b/src/mobx/stores/lockedCvxDelegationStore.ts
@@ -117,6 +117,14 @@ class LockedCvxDelegationStore {
 
 	async loadVotiumRewardsInformation(): Promise<void> {
 		try {
+			const {
+				network: { network },
+			} = this.store;
+
+			if (network.id !== NETWORK_IDS.ETH) {
+				return;
+			}
+
 			const [totalEarned, unclaimedBalance] = await Promise.all([
 				this.getTotalVotiumRewards(),
 				this.getUnclaimedVotiumRewards(),


### PR DESCRIPTION
Currently, all the slugs of all the networks are stored in the same object. This was causing conflicts in vaults that have the same name but live in different networks.

We can solve this by separating the slugs by chain symbol just like the other sett and token caches.