### PR TITLE
fix: don't display tooltips if no vault sources

### DIFF
--- a/src/components-v2/landing/VaultItemApr.tsx
+++ b/src/components-v2/landing/VaultItemApr.tsx
@@ -32,7 +32,7 @@ export const VaultItemApr = ({ vault, multiplier }: Props): JSX.Element => {
 	const classes = useStyles();
 	const apr = getAprMessage(vault);
 
-	if (vault.state === VaultState.Deprecated) {
+	if (vault.state === VaultState.Deprecated || vault.sources.length === 0) {
 		return (
 			<Typography className={classes.normalCursor} variant="body1" color={'textPrimary'}>
 				{apr}


### PR DESCRIPTION
closes #1521