### PR TITLE
fix: early return on undefined network

### DIFF
--- a/src/mobx/stores/OnboardStore.ts
+++ b/src/mobx/stores/OnboardStore.ts
@@ -85,7 +85,11 @@ export class OnboardStore {
 		}
 	});
 
-	networkListener = action(async (network: number) => {
+	networkListener = action(async (network: number | undefined) => {
+		if (!network) {
+			return;
+		}
+
 		if (isSupportedNetwork(network)) {
 			this.onSupportedNetwork = true;
 			await this.store.updateNetwork(network);


### PR DESCRIPTION
currently in prod if you disconnect your wallet the app crashes.

onboard.js is sending undefined as `networkId`, as per https://github.com/blocknative/onboard/blob/develop/src/onboard.ts#L167 it should not be possible but is causing problems in the app making the network to be undefined in https://github.com/Badger-Finance/v2-ui/blob/development/src/mobx/RootStore.ts#L82-L83

