### PR TITLE
fix: don't pass network name to onboard constructor

### DIFF
--- a/src/mobx/stores/OnboardStore.ts
+++ b/src/mobx/stores/OnboardStore.ts
@@ -135,7 +135,6 @@ export class OnboardStore {
 		return {
 			dappId: BLOCKNATIVE_API_KEY,
 			networkId: config.id,
-			networkName: config.network,
 			blockPollingInterval: 15000,
 			darkMode: true,
 			subscriptions: {


### PR DESCRIPTION
closes #1765

The root of the issue is in the Onboard instantiation, we're currently passing the network name as a parameter which was causing some issues in this function: https://github.com/blocknative/onboard/blob/develop/src/utilities.ts#L404.

We're currently using the name [`ethereum`](https://github.com/Badger-Finance/badger-sdk/blob/main/src/config/enums/network.enum.ts#L2) for mainnet, which for some reason, it is causing problems with portis. 

The network name is not required, I checked in their react demo and they're not setting it: https://github.com/blocknative/react-demo/blob/master/src/services.js#L104-L108. By not passing it as a parameter we trigger the usage of their networkId <> networkName mapping instead of ours.

Note that the mapping is only used for some wallets, in their example, they use way more wallets than us so we should be fine.

