### PR TITLE
chore(network-selector): display hover color when the gas options are displayed

### DIFF
--- a/src/components-v2/network-selector/NetworkOption.tsx
+++ b/src/components-v2/network-selector/NetworkOption.tsx
@@ -10,12 +10,16 @@ import { observer } from 'mobx-react-lite';
 import { NetworkConfig } from '@badger-dao/sdk/lib/config/network/network.config';
 import { StoreContext } from '../../mobx/store-context';
 import MenuItem from 'ui-library/MenuItem';
+import clsx from 'clsx';
 
 const useStyles = makeStyles((theme) => ({
 	networkListIcon: {
 		width: 17,
 		height: 17,
 		marginRight: theme.spacing(1),
+	},
+	hoveredButton: {
+		backgroundColor: '#545454',
 	},
 	root: {
 		minWidth: 234,
@@ -24,6 +28,7 @@ const useStyles = makeStyles((theme) => ({
 		zIndex: 2,
 	},
 	gasButton: {
+		marginRight: -12,
 		[theme.breakpoints.up('lg')]: {
 			'&:hover': {
 				backgroundColor: 'inherit',
@@ -70,6 +75,7 @@ const NetworkOption = ({ network, onSelect }: Props): JSX.Element => {
 			onClick={!isMobile ? handleClick : undefined}
 			onMouseEnter={!isMobile ? toggleOpen : undefined}
 			onMouseLeave={!isMobile ? toggleOpen : undefined}
+			className={clsx(open && classes.hoveredButton)}
 		>
 			<Grid container>
 				<Grid item xs container alignItems="center" onClick={isMobile ? handleClick : undefined}>

--- a/src/tests/__snapshots__/NetworkGasWidget.test.tsx.snap
+++ b/src/tests/__snapshots__/NetworkGasWidget.test.tsx.snap
@@ -43,18 +43,18 @@ exports[`NetworkGasWidget displays network options 1`] = `
       </li>
       <div
         aria-disabled="false"
-        class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+        class="MuiButtonBase-root-33 MuiListItem-root-68 makeStyles-hoveredButton-63 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
         role="button"
         tabindex="0"
       >
         <div
-          class="MuiGrid-root-78 MuiGrid-container-79"
+          class="MuiGrid-root-79 MuiGrid-container-80"
         >
           <div
-            class="MuiGrid-root-78 MuiGrid-container-79 MuiGrid-item-80 MuiGrid-align-items-xs-center-87 MuiGrid-grid-xs-true-112"
+            class="MuiGrid-root-79 MuiGrid-container-80 MuiGrid-item-81 MuiGrid-align-items-xs-center-88 MuiGrid-grid-xs-true-113"
           >
             <div
-              class="MuiListItemIcon-root-182 makeStyles-root-181"
+              class="MuiListItemIcon-root-183 makeStyles-root-182"
             >
               <img
                 alt="Ethereum icon"
@@ -63,26 +63,26 @@ exports[`NetworkGasWidget displays network options 1`] = `
               />
             </div>
             <div
-              class="MuiListItemText-root-185"
+              class="MuiListItemText-root-186"
             >
               <span
-                class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+                class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
               >
                 Ethereum
               </span>
             </div>
           </div>
           <div
-            class="MuiGrid-root-78 MuiGrid-item-80 MuiGrid-grid-xs-auto-111"
+            class="MuiGrid-root-79 MuiGrid-item-81 MuiGrid-grid-xs-auto-112"
           >
             <button
               aria-label="show gas options"
-              class="MuiButtonBase-root-33 MuiIconButton-root-221 makeStyles-gasButton-65"
+              class="MuiButtonBase-root-33 MuiIconButton-root-222 makeStyles-gasButton-66"
               tabindex="0"
               type="button"
             >
               <span
-                class="MuiIconButton-label-229"
+                class="MuiIconButton-label-230"
               >
                 <img
                   alt="display gas options icon"
@@ -101,18 +101,18 @@ exports[`NetworkGasWidget displays network options 1`] = `
       </div>
       <div
         aria-disabled="false"
-        class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+        class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
         role="button"
         tabindex="0"
       >
         <div
-          class="MuiGrid-root-78 MuiGrid-container-79"
+          class="MuiGrid-root-79 MuiGrid-container-80"
         >
           <div
-            class="MuiGrid-root-78 MuiGrid-container-79 MuiGrid-item-80 MuiGrid-align-items-xs-center-87 MuiGrid-grid-xs-true-112"
+            class="MuiGrid-root-79 MuiGrid-container-80 MuiGrid-item-81 MuiGrid-align-items-xs-center-88 MuiGrid-grid-xs-true-113"
           >
             <div
-              class="MuiListItemIcon-root-182 makeStyles-root-181"
+              class="MuiListItemIcon-root-183 makeStyles-root-182"
             >
               <img
                 alt="Local icon"
@@ -121,10 +121,10 @@ exports[`NetworkGasWidget displays network options 1`] = `
               />
             </div>
             <div
-              class="MuiListItemText-root-185"
+              class="MuiListItemText-root-186"
             >
               <span
-                class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+                class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
               >
                 Local
               </span>
@@ -137,18 +137,18 @@ exports[`NetworkGasWidget displays network options 1`] = `
       </div>
       <div
         aria-disabled="false"
-        class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+        class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
         role="button"
         tabindex="0"
       >
         <div
-          class="MuiGrid-root-78 MuiGrid-container-79"
+          class="MuiGrid-root-79 MuiGrid-container-80"
         >
           <div
-            class="MuiGrid-root-78 MuiGrid-container-79 MuiGrid-item-80 MuiGrid-align-items-xs-center-87 MuiGrid-grid-xs-true-112"
+            class="MuiGrid-root-79 MuiGrid-container-80 MuiGrid-item-81 MuiGrid-align-items-xs-center-88 MuiGrid-grid-xs-true-113"
           >
             <div
-              class="MuiListItemIcon-root-182 makeStyles-root-181"
+              class="MuiListItemIcon-root-183 makeStyles-root-182"
             >
               <img
                 alt="Polygon icon"
@@ -157,10 +157,10 @@ exports[`NetworkGasWidget displays network options 1`] = `
               />
             </div>
             <div
-              class="MuiListItemText-root-185"
+              class="MuiListItemText-root-186"
             >
               <span
-                class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+                class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
               >
                 Polygon
               </span>
@@ -173,18 +173,18 @@ exports[`NetworkGasWidget displays network options 1`] = `
       </div>
       <div
         aria-disabled="false"
-        class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+        class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
         role="button"
         tabindex="0"
       >
         <div
-          class="MuiGrid-root-78 MuiGrid-container-79"
+          class="MuiGrid-root-79 MuiGrid-container-80"
         >
           <div
-            class="MuiGrid-root-78 MuiGrid-container-79 MuiGrid-item-80 MuiGrid-align-items-xs-center-87 MuiGrid-grid-xs-true-112"
+            class="MuiGrid-root-79 MuiGrid-container-80 MuiGrid-item-81 MuiGrid-align-items-xs-center-88 MuiGrid-grid-xs-true-113"
           >
             <div
-              class="MuiListItemIcon-root-182 makeStyles-root-181"
+              class="MuiListItemIcon-root-183 makeStyles-root-182"
             >
               <img
                 alt="Binance Smart Chain icon"
@@ -193,10 +193,10 @@ exports[`NetworkGasWidget displays network options 1`] = `
               />
             </div>
             <div
-              class="MuiListItemText-root-185"
+              class="MuiListItemText-root-186"
             >
               <span
-                class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+                class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
               >
                 Binance Smart Chain
               </span>
@@ -209,18 +209,18 @@ exports[`NetworkGasWidget displays network options 1`] = `
       </div>
       <div
         aria-disabled="false"
-        class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+        class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
         role="button"
         tabindex="0"
       >
         <div
-          class="MuiGrid-root-78 MuiGrid-container-79"
+          class="MuiGrid-root-79 MuiGrid-container-80"
         >
           <div
-            class="MuiGrid-root-78 MuiGrid-container-79 MuiGrid-item-80 MuiGrid-align-items-xs-center-87 MuiGrid-grid-xs-true-112"
+            class="MuiGrid-root-79 MuiGrid-container-80 MuiGrid-item-81 MuiGrid-align-items-xs-center-88 MuiGrid-grid-xs-true-113"
           >
             <div
-              class="MuiListItemIcon-root-182 makeStyles-root-181"
+              class="MuiListItemIcon-root-183 makeStyles-root-182"
             >
               <img
                 alt="Arbitrum icon"
@@ -229,10 +229,10 @@ exports[`NetworkGasWidget displays network options 1`] = `
               />
             </div>
             <div
-              class="MuiListItemText-root-185"
+              class="MuiListItemText-root-186"
             >
               <span
-                class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+                class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
               >
                 Arbitrum
               </span>
@@ -245,18 +245,18 @@ exports[`NetworkGasWidget displays network options 1`] = `
       </div>
       <div
         aria-disabled="false"
-        class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+        class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
         role="button"
         tabindex="0"
       >
         <div
-          class="MuiGrid-root-78 MuiGrid-container-79"
+          class="MuiGrid-root-79 MuiGrid-container-80"
         >
           <div
-            class="MuiGrid-root-78 MuiGrid-container-79 MuiGrid-item-80 MuiGrid-align-items-xs-center-87 MuiGrid-grid-xs-true-112"
+            class="MuiGrid-root-79 MuiGrid-container-80 MuiGrid-item-81 MuiGrid-align-items-xs-center-88 MuiGrid-grid-xs-true-113"
           >
             <div
-              class="MuiListItemIcon-root-182 makeStyles-root-181"
+              class="MuiListItemIcon-root-183 makeStyles-root-182"
             >
               <img
                 alt="Fantom icon"
@@ -265,10 +265,10 @@ exports[`NetworkGasWidget displays network options 1`] = `
               />
             </div>
             <div
-              class="MuiListItemText-root-185"
+              class="MuiListItemText-root-186"
             >
               <span
-                class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+                class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
               >
                 Fantom
               </span>
@@ -282,28 +282,28 @@ exports[`NetworkGasWidget displays network options 1`] = `
     </nav>
   </div>
   <div
-    class="makeStyles-popper-64"
+    class="makeStyles-popper-65"
     role="tooltip"
     style="position: absolute; top: 0px; left: 0px;"
     x-placement="right-start"
   >
     <div
-      class="MuiPaper-root-231 MuiPaper-elevation1-235 MuiPaper-rounded-232"
+      class="MuiPaper-root-232 MuiPaper-elevation1-236 MuiPaper-rounded-233"
     >
       <nav
-        class="MuiList-root-50 makeStyles-root-49 makeStyles-root-230 MuiList-padding-51"
+        class="MuiList-root-50 makeStyles-root-49 makeStyles-root-231 MuiList-padding-51"
       >
         <div
           aria-disabled="false"
-          class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+          class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
           role="button"
           tabindex="0"
         >
           <div
-            class="MuiListItemText-root-185"
+            class="MuiListItemText-root-186"
           >
             <span
-              class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+              class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
             >
                
               43
@@ -315,15 +315,15 @@ exports[`NetworkGasWidget displays network options 1`] = `
         </div>
         <div
           aria-disabled="false"
-          class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+          class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
           role="button"
           tabindex="0"
         >
           <div
-            class="MuiListItemText-root-185"
+            class="MuiListItemText-root-186"
           >
             <span
-              class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+              class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
             >
                
               39
@@ -335,15 +335,15 @@ exports[`NetworkGasWidget displays network options 1`] = `
         </div>
         <div
           aria-disabled="false"
-          class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+          class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
           role="button"
           tabindex="0"
         >
           <div
-            class="MuiListItemText-root-185"
+            class="MuiListItemText-root-186"
           >
             <span
-              class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+              class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
             >
                
               34
@@ -355,15 +355,15 @@ exports[`NetworkGasWidget displays network options 1`] = `
         </div>
         <div
           aria-disabled="false"
-          class="MuiButtonBase-root-33 MuiListItem-root-67 MuiListItem-gutters-74 MuiListItem-button-75 makeStyles-button-66"
+          class="MuiButtonBase-root-33 MuiListItem-root-68 MuiListItem-gutters-75 MuiListItem-button-76 makeStyles-button-67"
           role="button"
           tabindex="0"
         >
           <div
-            class="MuiListItemText-root-185"
+            class="MuiListItemText-root-186"
           >
             <span
-              class="MuiTypography-root-191 MuiListItemText-primary-189 makeStyles-primary-184 MuiTypography-body1-193 MuiTypography-displayBlock-220"
+              class="MuiTypography-root-192 MuiListItemText-primary-190 makeStyles-primary-185 MuiTypography-body1-194 MuiTypography-displayBlock-221"
             >
                
               30


### PR DESCRIPTION
addresses feedback from Heloise:

> after clicking on the arrow of the Ethereum network, it doesn't show the Ethereum network as selected, it only show the arrow.
Here it shows without the Ethereum background having a light grey background
![image](https://user-images.githubusercontent.com/38574891/158908975-f9938997-2bb9-4131-bee6-a1c513c8de78.png)
