### PR TITLE
fix: boost optimizer display on iOS

### DIFF
--- a/src/components/Boost/Optimizer.tsx
+++ b/src/components/Boost/Optimizer.tsx
@@ -13,15 +13,11 @@ import { MIN_BOOST_LEVEL } from '../../config/system/boost-ranks';
 
 const useStyles = makeStyles((theme) => ({
 	calculatorContainer: {
-		width: '100%',
-		boxSizing: 'border-box',
 		padding: theme.spacing(3),
-		flexDirection: 'column',
-		[theme.breakpoints.up('md')]: {
-			height: '100%',
-		},
+		alignSelf: 'stretch',
 	},
 	divider: {
+		width: '100%',
 		[theme.breakpoints.down('sm')]: {
 			margin: theme.spacing(3, 0, 0, 1),
 		},
@@ -156,13 +152,13 @@ export const Optimizer = observer((): JSX.Element => {
 
 	return (
 		<Grid container spacing={2}>
-			<Grid item xs={12} lg>
-				<Grid container component={Paper} className={classes.calculatorContainer}>
+			<Grid container item xs={12} lg>
+				<Grid container direction="column" component={Paper} className={classes.calculatorContainer}>
 					<Grid item>
 						<OptimizerHeader multiplier={multiplier} onReset={handleReset} />
 					</Grid>
 					<Divider className={classes.divider} />
-					<Grid item container xs direction="column" justifyContent="center">
+					<Grid item>
 						<OptimizerBody
 							multiplier={multiplier}
 							native={native || ''}

--- a/src/tests/boost-optimizer/__snapshots__/Optimizer.test.tsx.snap
+++ b/src/tests/boost-optimizer/__snapshots__/Optimizer.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Boost Optimizer can change native and non native balances 1`] = `
     class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-spacing-xs-2-30"
   >
     <div
-      class="MuiGrid-root-6 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
+      class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
     >
       <div
-        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiPaper-elevation1-113 MuiPaper-rounded-110"
+        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiGrid-direction-xs-column-10 MuiPaper-elevation1-113 MuiPaper-rounded-110"
       >
         <div
           class="MuiGrid-root-6 MuiGrid-item-8"
@@ -66,7 +66,7 @@ exports[`Boost Optimizer can change native and non native balances 1`] = `
           class="MuiDivider-root-227 makeStyles-divider-2"
         />
         <div
-          class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-direction-xs-column-10 MuiGrid-justify-content-xs-center-24 MuiGrid-grid-xs-true-40"
+          class="MuiGrid-root-6 MuiGrid-item-8"
         >
           <div
             class="MuiGrid-root-6 makeStyles-content-234 MuiGrid-container-7"
@@ -935,10 +935,10 @@ exports[`Boost Optimizer can decrease balances through the increase button 1`] =
     class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-spacing-xs-2-30"
   >
     <div
-      class="MuiGrid-root-6 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
+      class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
     >
       <div
-        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiPaper-elevation1-113 MuiPaper-rounded-110"
+        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiGrid-direction-xs-column-10 MuiPaper-elevation1-113 MuiPaper-rounded-110"
       >
         <div
           class="MuiGrid-root-6 MuiGrid-item-8"
@@ -995,7 +995,7 @@ exports[`Boost Optimizer can decrease balances through the increase button 1`] =
           class="MuiDivider-root-227 makeStyles-divider-2"
         />
         <div
-          class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-direction-xs-column-10 MuiGrid-justify-content-xs-center-24 MuiGrid-grid-xs-true-40"
+          class="MuiGrid-root-6 MuiGrid-item-8"
         >
           <div
             class="MuiGrid-root-6 makeStyles-content-234 MuiGrid-container-7"
@@ -1881,10 +1881,10 @@ exports[`Boost Optimizer can increase balances through the increase button 1`] =
     class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-spacing-xs-2-30"
   >
     <div
-      class="MuiGrid-root-6 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
+      class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
     >
       <div
-        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiPaper-elevation1-113 MuiPaper-rounded-110"
+        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiGrid-direction-xs-column-10 MuiPaper-elevation1-113 MuiPaper-rounded-110"
       >
         <div
           class="MuiGrid-root-6 MuiGrid-item-8"
@@ -1941,7 +1941,7 @@ exports[`Boost Optimizer can increase balances through the increase button 1`] =
           class="MuiDivider-root-227 makeStyles-divider-2"
         />
         <div
-          class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-direction-xs-column-10 MuiGrid-justify-content-xs-center-24 MuiGrid-grid-xs-true-40"
+          class="MuiGrid-root-6 MuiGrid-item-8"
         >
           <div
             class="MuiGrid-root-6 makeStyles-content-234 MuiGrid-container-7"
@@ -2828,10 +2828,10 @@ exports[`Boost Optimizer can jump to rank 1`] = `
     class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-spacing-xs-2-30"
   >
     <div
-      class="MuiGrid-root-6 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
+      class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
     >
       <div
-        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiPaper-elevation1-113 MuiPaper-rounded-110"
+        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiGrid-direction-xs-column-10 MuiPaper-elevation1-113 MuiPaper-rounded-110"
       >
         <div
           class="MuiGrid-root-6 MuiGrid-item-8"
@@ -2888,7 +2888,7 @@ exports[`Boost Optimizer can jump to rank 1`] = `
           class="MuiDivider-root-227 makeStyles-divider-2"
         />
         <div
-          class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-direction-xs-column-10 MuiGrid-justify-content-xs-center-24 MuiGrid-grid-xs-true-40"
+          class="MuiGrid-root-6 MuiGrid-item-8"
         >
           <div
             class="MuiGrid-root-6 makeStyles-content-234 MuiGrid-container-7"
@@ -3764,10 +3764,10 @@ exports[`Boost Optimizer displays correct information 1`] = `
     class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-spacing-xs-2-30"
   >
     <div
-      class="MuiGrid-root-6 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
+      class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
     >
       <div
-        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiPaper-elevation1-113 MuiPaper-rounded-110"
+        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiGrid-direction-xs-column-10 MuiPaper-elevation1-113 MuiPaper-rounded-110"
       >
         <div
           class="MuiGrid-root-6 MuiGrid-item-8"
@@ -3824,7 +3824,7 @@ exports[`Boost Optimizer displays correct information 1`] = `
           class="MuiDivider-root-227 makeStyles-divider-2"
         />
         <div
-          class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-direction-xs-column-10 MuiGrid-justify-content-xs-center-24 MuiGrid-grid-xs-true-40"
+          class="MuiGrid-root-6 MuiGrid-item-8"
         >
           <div
             class="MuiGrid-root-6 makeStyles-content-234 MuiGrid-container-7"
@@ -4692,10 +4692,10 @@ exports[`Boost Optimizer shows empty non native message 1`] = `
     class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-spacing-xs-2-30"
   >
     <div
-      class="MuiGrid-root-6 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
+      class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
     >
       <div
-        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiPaper-elevation1-113 MuiPaper-rounded-110"
+        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiGrid-direction-xs-column-10 MuiPaper-elevation1-113 MuiPaper-rounded-110"
       >
         <div
           class="MuiGrid-root-6 MuiGrid-item-8"
@@ -4752,7 +4752,7 @@ exports[`Boost Optimizer shows empty non native message 1`] = `
           class="MuiDivider-root-227 makeStyles-divider-2"
         />
         <div
-          class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-direction-xs-column-10 MuiGrid-justify-content-xs-center-24 MuiGrid-grid-xs-true-40"
+          class="MuiGrid-root-6 MuiGrid-item-8"
         >
           <div
             class="MuiGrid-root-6 makeStyles-content-234 MuiGrid-container-7"
@@ -5620,10 +5620,10 @@ exports[`Boost Optimizer supports no wallet mode 1`] = `
     class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-spacing-xs-2-30"
   >
     <div
-      class="MuiGrid-root-6 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
+      class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-grid-xs-12-52 MuiGrid-grid-lg-true-82"
     >
       <div
-        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiPaper-elevation1-113 MuiPaper-rounded-110"
+        class="MuiPaper-root-109 MuiGrid-root-6 makeStyles-calculatorContainer-1 MuiGrid-container-7 MuiGrid-direction-xs-column-10 MuiPaper-elevation1-113 MuiPaper-rounded-110"
       >
         <div
           class="MuiGrid-root-6 MuiGrid-item-8"
@@ -5680,7 +5680,7 @@ exports[`Boost Optimizer supports no wallet mode 1`] = `
           class="MuiDivider-root-227 makeStyles-divider-2"
         />
         <div
-          class="MuiGrid-root-6 MuiGrid-container-7 MuiGrid-item-8 MuiGrid-direction-xs-column-10 MuiGrid-justify-content-xs-center-24 MuiGrid-grid-xs-true-40"
+          class="MuiGrid-root-6 MuiGrid-item-8"
         >
           <div
             class="MuiGrid-root-6 makeStyles-content-234 MuiGrid-container-7"


### PR DESCRIPTION
- replace `height:100%` with `align-self: stretch`

this was causing issues in iOS, here's the explanation: https://stackoverflow.com/questions/33636796/chrome-safari-not-filling-100-height-of-flex-parent/33644245#33644245

closes #1966 
