### PR TITLE
Add tally wallet to onboard config

### DIFF
--- a/src/config/wallets.ts
+++ b/src/config/wallets.ts
@@ -27,10 +27,14 @@ export const getOnboardWallets = (config: NetworkConfig): WalletProviderInfo[] =
 	const networkRPC = rpc[config.network];
 	switch (config.network) {
 		case Network.BinanceSmartChain:
-			return [{ walletName: 'metamask', preferred: true }];
+			return [
+				{ walletName: 'metamask', preferred: true },
+				{ walletName: 'tally', preferred: true },
+			];
 		default:
 			return [
 				{ walletName: 'metamask', preferred: true },
+				{ walletName: 'tally', preferred: true },
 				{ walletName: 'coinbase', preferred: true },
 				{
 					walletName: 'ledger',

--- a/src/config/wallets.ts
+++ b/src/config/wallets.ts
@@ -27,10 +27,7 @@ export const getOnboardWallets = (config: NetworkConfig): WalletProviderInfo[] =
 	const networkRPC = rpc[config.network];
 	switch (config.network) {
 		case Network.BinanceSmartChain:
-			return [
-				{ walletName: 'metamask', preferred: true },
-				{ walletName: 'tally', preferred: true },
-			];
+			return [{ walletName: 'metamask', preferred: true }];
 		default:
 			return [
 				{ walletName: 'metamask', preferred: true },


### PR DESCRIPTION
Add tally wallet to onboard config as an option.
Tally wallet will show even if uninstall and redirect to install instructions if clicked (similiar to metamask and other preferred wallets)

https://www.loom.com/share/2e54cde9e25f4c76a94890ab9156b248