### PR TITLE
refactor: use calculated token balances value in detail page

### DIFF
--- a/src/components-v2/vault-detail/MainContent.tsx
+++ b/src/components-v2/vault-detail/MainContent.tsx
@@ -9,6 +9,7 @@ import { BadgerVault } from '../../mobx/model/vaults/badger-vault';
 import { NewVaultWarning } from './NewVaultWarning';
 import { BalanceNamespace } from 'web3/config/namespaces';
 import { VaultDTO, VaultState } from '@badger-dao/sdk';
+import { defaultVaultBalance } from './utils';
 
 const useStyles = makeStyles((theme) => ({
 	content: {
@@ -42,18 +43,13 @@ export const MainContent = observer(({ badgerVault, vault }: Props): JSX.Element
 
 	const classes = useStyles();
 	const tokenBalance = user.getBalance(BalanceNamespace.Token, badgerVault);
-	const settBalance = user.getVaultBalance(vault);
+	const userData = user.accountDetails?.data[vault.vaultToken] ?? defaultVaultBalance(vault);
 
 	return (
 		<Grid container className={classes.content}>
 			{onboard.isActive() && (
 				<Grid container className={classes.holdingsContainer}>
-					<Holdings
-						vault={vault}
-						badgerVault={badgerVault}
-						tokenBalance={tokenBalance}
-						userData={settBalance}
-					/>
+					<Holdings vault={vault} badgerVault={badgerVault} tokenBalance={tokenBalance} userData={userData} />
 				</Grid>
 			)}
 			<Grid container spacing={1}>

--- a/src/components-v2/vault-detail/holdings/HoldingItem.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingItem.tsx
@@ -1,12 +1,8 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Divider, Grid, Paper, Typography } from '@material-ui/core';
-import BigNumber from 'bignumber.js';
-import { formatWithoutExtraZeros, numberWithCommas } from '../../../mobx/utils/helpers';
-import { observer } from 'mobx-react-lite';
 import { VaultDTO } from '@badger-dao/sdk';
 import VaultLogo from '../../landing/VaultLogo';
-import { StoreContext } from '../../../mobx/store-context';
 
 const useStyles = makeStyles((theme) => ({
 	titleContainer: {
@@ -41,19 +37,13 @@ const useStyles = makeStyles((theme) => ({
 interface Props {
 	vault: VaultDTO;
 	name: string;
-	balance: BigNumber.Value;
-	value: BigNumber.Value;
+	balance: string;
+	value: string;
 	helpIcon?: React.ReactNode;
 }
 
-const displayUsdBalance = (value: BigNumber.Value) => `~$${numberWithCommas(formatWithoutExtraZeros(value, 2))}`;
-
-export const HoldingItem = observer(({ vault, name, balance, value, helpIcon }: Props): JSX.Element => {
-	const { vaults } = useContext(StoreContext);
+export const HoldingItem = ({ vault, name, balance, value, helpIcon }: Props): JSX.Element => {
 	const classes = useStyles();
-	const depositToken = vaults.getToken(vault.underlyingToken);
-	const decimals = depositToken?.decimals || 18;
-
 	return (
 		<Paper className={classes.cardContainer}>
 			<div className={classes.titleContainer}>
@@ -67,13 +57,13 @@ export const HoldingItem = observer(({ vault, name, balance, value, helpIcon }: 
 						<VaultLogo tokens={vault.tokens} />
 					</div>
 					<div>
-						<Typography variant="h5">{formatWithoutExtraZeros(balance, decimals)}</Typography>
+						<Typography variant="h5">{balance}</Typography>
 						<Typography variant="body2" color="textSecondary">
-							{displayUsdBalance(value)}
+							{value}
 						</Typography>
 					</div>
 				</Box>
 			</Grid>
 		</Paper>
 	);
-});
+};

--- a/src/components-v2/vault-detail/holdings/Holdings.tsx
+++ b/src/components-v2/vault-detail/holdings/Holdings.tsx
@@ -63,7 +63,7 @@ export const Holdings = observer(({ tokenBalance, userData, vault, badgerVault }
 						vault={vault}
 						name="Total Deposited"
 						balance={depositBalance.balanceDisplay()}
-						value={depositBalance.balanceValueDisplay(vaults.vaultsFilters.currency) ?? '$0'}
+						value={depositBalance.balanceValueDisplay(vaults.vaultsFilters.currency) ?? '0'}
 						helpIcon={<TokenDistributionIcon settBalance={userData} />}
 					/>
 				</Grid>

--- a/src/components-v2/vault-detail/holdings/Holdings.tsx
+++ b/src/components-v2/vault-detail/holdings/Holdings.tsx
@@ -50,8 +50,6 @@ export const Holdings = observer(({ tokenBalance, userData, vault, badgerVault }
 	const { earnedBalance, earnedValue } = userData;
 	const decimals = depositBalance.token.decimals;
 
-	console.log(depositBalance.balance.toString(), depositBalance.price.toString());
-
 	return (
 		<Grid container>
 			<Grid container>

--- a/src/components-v2/vault-detail/holdings/Holdings.tsx
+++ b/src/components-v2/vault-detail/holdings/Holdings.tsx
@@ -11,6 +11,7 @@ import { hasBalance } from '../utils';
 import { TokenDistributionIcon } from './TokenDistributionIcon';
 import { VaultDTO, VaultData } from '@badger-dao/sdk';
 import { shouldDisplayEarnings } from 'utils/componentHelpers';
+import { formatWithoutExtraZeros, numberWithCommas } from '../../../mobx/utils/helpers';
 
 const useStyles = makeStyles((theme) => ({
 	settInfoTitle: {
@@ -32,7 +33,7 @@ interface Props {
 }
 
 export const Holdings = observer(({ tokenBalance, userData, vault, badgerVault }: Props): JSX.Element | null => {
-	const { user } = React.useContext(StoreContext);
+	const { user, vaults } = React.useContext(StoreContext);
 	const isMediumSizeScreen = useMediaQuery(useTheme().breakpoints.up('sm'));
 	const classes = useStyles();
 	const canDeposit = user.onGuestList(vault);
@@ -45,7 +46,11 @@ export const Holdings = observer(({ tokenBalance, userData, vault, badgerVault }
 		);
 	}
 
-	const { earnedBalance, earnedValue, balance, value } = userData;
+	const depositBalance = user.getTokenBalance(vault.vaultToken);
+	const { earnedBalance, earnedValue } = userData;
+	const decimals = depositBalance.token.decimals;
+
+	console.log(depositBalance.balance.toString(), depositBalance.price.toString());
 
 	return (
 		<Grid container>
@@ -57,14 +62,19 @@ export const Holdings = observer(({ tokenBalance, userData, vault, badgerVault }
 					<HoldingItem
 						vault={vault}
 						name="Total Deposited"
-						balance={balance}
-						value={value}
+						balance={depositBalance.balanceDisplay()}
+						value={depositBalance.balanceValueDisplay(vaults.vaultsFilters.currency) ?? '$0'}
 						helpIcon={<TokenDistributionIcon settBalance={userData} />}
 					/>
 				</Grid>
 				{shouldDisplayEarnings(vault, userData) && (
 					<Grid item xs={12} sm>
-						<HoldingItem vault={vault} name="Total Earned" balance={earnedBalance} value={earnedValue} />
+						<HoldingItem
+							vault={vault}
+							name="Total Earned"
+							balance={formatWithoutExtraZeros(earnedBalance, decimals)}
+							value={`~$${numberWithCommas(formatWithoutExtraZeros(earnedValue, 2))}`}
+						/>
 					</Grid>
 				)}
 				{isMediumSizeScreen && (

--- a/src/mobx/stores/UserStore.ts
+++ b/src/mobx/stores/UserStore.ts
@@ -11,8 +11,7 @@ import { UserBalanceCache } from 'mobx/model/account/user-balance-cache';
 import { CachedTokenBalances } from 'mobx/model/account/cached-token-balances';
 import { VaultCaps } from 'mobx/model/vaults/vault-cap copy';
 import { RewardMerkleClaim } from '../model/rewards/reward-merkle-claim';
-import { defaultVaultBalance } from 'components-v2/vault-detail/utils';
-import { Account, BouncerType, MerkleProof, Network, VaultDTO, VaultData } from '@badger-dao/sdk';
+import { Account, BouncerType, MerkleProof, Network, VaultDTO } from '@badger-dao/sdk';
 import { fetchClaimProof } from 'mobx/utils/apiV2';
 import { Multicall } from 'ethereum-multicall';
 import { extractBalanceRequestResults, RequestExtractedResults } from '../utils/user-balances';
@@ -106,27 +105,6 @@ export default class UserStore {
 			actions.push(user.loadAccountDetails(queryAddress));
 			await Promise.all(actions);
 		}
-	}
-
-	getVaultBalance(vault: VaultDTO): VaultData {
-		const currentVaultBalance = this.getTokenBalance(vault.vaultToken);
-		let settBalance = this.accountDetails?.data[vault.vaultToken];
-
-		/**
-		 * settBalance data is populated via events from TheGraph and it is possible for it to be behind / fail.
-		 * As such, the app also has internally the state of user deposits. Should a settBalance not be available
-		 * for a user - this is likely because they have *just* deposited and their deposit does not show in the
-		 * graph yet.
-		 *
-		 * This override simulates a zero earnings settBalance and providers the proper currently deposited
-		 * underlying token amount in the expected downstream object.
-		 */
-		if (!settBalance) {
-			settBalance = defaultVaultBalance(vault);
-			settBalance.balance = currentVaultBalance.balance.toNumber() * vault.pricePerFullShare;
-		}
-
-		return settBalance;
 	}
 
 	getBalance(namespace: BalanceNamespace, vault: BadgerVault): TokenBalance {

--- a/src/tests/sett-details/Holdings.test.tsx
+++ b/src/tests/sett-details/Holdings.test.tsx
@@ -1,9 +1,22 @@
 import React from 'react';
 import { checkSnapshot } from 'tests/utils/snapshots';
-import { SAMPLE_BADGER_SETT, SAMPLE_VAULT, SAMPLE_VAULT_BALANCE, SAMPLE_TOKEN_BALANCE } from '../utils/samples';
+import {
+	SAMPLE_BADGER_SETT,
+	SAMPLE_VAULT,
+	SAMPLE_VAULT_BALANCE,
+	SAMPLE_TOKEN_BALANCE,
+	SAMPLE_EXCHANGES_RATES,
+} from '../utils/samples';
 import { Holdings } from '../../components-v2/vault-detail/holdings/Holdings';
+import UserStore from '../../mobx/stores/UserStore';
+import store from '../../mobx/RootStore';
 
-describe('Breadcrumb', () => {
+describe('Holdings', () => {
+	beforeEach(() => {
+		jest.spyOn(UserStore.prototype, 'getTokenBalance').mockReturnValue(SAMPLE_TOKEN_BALANCE);
+		store.prices.exchangeRates = SAMPLE_EXCHANGES_RATES;
+	});
+
 	it('displays holdings with no balance', () => {
 		checkSnapshot(
 			<Holdings
@@ -16,6 +29,7 @@ describe('Breadcrumb', () => {
 	});
 
 	it('displays holdings with balance', () => {
+		jest.spyOn(UserStore.prototype, 'getTokenBalance').mockReturnValue(SAMPLE_TOKEN_BALANCE);
 		checkSnapshot(
 			<Holdings
 				vault={SAMPLE_VAULT}

--- a/src/tests/sett-details/__snapshots__/Holdings.test.tsx.snap
+++ b/src/tests/sett-details/__snapshots__/Holdings.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Breadcrumb displays holdings with balance 1`] = `
+exports[`Holdings displays holdings with balance 1`] = `
 <div>
   <div
     class="MuiGrid-root-3 MuiGrid-container-4"
@@ -69,12 +69,12 @@ exports[`Breadcrumb displays holdings with balance 1`] = `
                 <h5
                   class="MuiTypography-root-106 MuiTypography-h5-115"
                 >
-                  400
+                  1.999000000000000000
                 </h5>
                 <p
                   class="MuiTypography-root-106 MuiTypography-body2-107 MuiTypography-colorTextSecondary-132"
                 >
-                  ~$21,219,315.21
+                  $114,098.03
                 </p>
               </div>
             </div>
@@ -139,7 +139,7 @@ exports[`Breadcrumb displays holdings with balance 1`] = `
 </div>
 `;
 
-exports[`Breadcrumb displays holdings with no balance 1`] = `
+exports[`Holdings displays holdings with no balance 1`] = `
 <div>
   <div
     class="MuiGrid-root-3 MuiGrid-container-4"
@@ -208,12 +208,12 @@ exports[`Breadcrumb displays holdings with no balance 1`] = `
                 <h5
                   class="MuiTypography-root-106 MuiTypography-h5-115"
                 >
-                  400
+                  1.999000000000000000
                 </h5>
                 <p
                   class="MuiTypography-root-106 MuiTypography-body2-107 MuiTypography-colorTextSecondary-132"
                 >
-                  ~$21,219,315.21
+                  $114,098.03
                 </p>
               </div>
             </div>

--- a/src/tests/utils/samples.ts
+++ b/src/tests/utils/samples.ts
@@ -191,8 +191,8 @@ export const SAMPLE_TOKEN_BALANCE = new TokenBalance(
 		symbol: 'curve-renBTC-wBTC-sBTC',
 		decimals: 18,
 	},
-	new BigNumber(2580.4779797767615),
-	new BigNumber(135697015.0445408),
+	new BigNumber(1.999 * 1e18),
+	new BigNumber(13.16),
 );
 
 export const SAMPLE_VAULTS: VaultDTO[] = [


### PR DESCRIPTION
currently, there's a mismatch between the deposited balances on the landing page and the detail page because we're using the account data deposit balances information from the API on the detail page but we're not on the landing page.

this PR changes the implementation in the detail page to use the same values as the main page.

closes #2011