### PR TITLE
fix: remove always changing dependency

### DIFF
--- a/src/components-v2/NetworkURLManager/index.tsx
+++ b/src/components-v2/NetworkURLManager/index.tsx
@@ -6,7 +6,6 @@ import { NETWORK_IDS, NETWORK_IDS_TO_NAMES } from '../../config/constants';
 
 const NetworkURLManager: React.FC = ({ children }) => {
 	const { router, onboard } = useContext(StoreContext);
-	const urlChainId = router.queryParams?.chain;
 	const chainId = onboard.chainId;
 	const previousChainId = usePrevious(onboard.chainId);
 
@@ -18,13 +17,14 @@ const NetworkURLManager: React.FC = ({ children }) => {
 		if (chainId !== previousChainId && onboard.isActive()) {
 			router.queryParams = { ...router.queryParams, chain: NETWORK_IDS_TO_NAMES[chainId as NETWORK_IDS] };
 		}
-	}, [chainId, previousChainId, urlChainId, router, onboard]);
+	}, [previousChainId, router, onboard]);
 
 	useEffect(() => {
+		const urlChainId = router.queryParams?.chain;
 		if (chainId && !urlChainId) {
 			router.queryParams = { ...router.queryParams, chain: NETWORK_IDS_TO_NAMES[chainId as NETWORK_IDS] };
 		}
-	}, [chainId, router, urlChainId]);
+	}, [chainId, onboard, router]);
 
 	return <>{children}</>;
 };

--- a/src/components-v2/landing/VaultListItem.tsx
+++ b/src/components-v2/landing/VaultListItem.tsx
@@ -77,7 +77,11 @@ const VaultListItem = observer(({ vault }: VaultListItemProps): JSX.Element | nu
 	const isTablet = useMediaQuery(useTheme().breakpoints.only('md'));
 
 	const goToVaultDetail = async () => {
-		await router.goTo(routes.vaultDetail, { vaultName: vaults.getSlug(vault.vaultToken) });
+		await router.goTo(
+			routes.vaultDetail,
+			{ vaultName: vaults.getSlug(vault.vaultToken) },
+			{ chain: router.queryParams?.chain },
+		);
 	};
 
 	const handleStatusClick = (event: MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
currently, there is a bug that's the "go to previous page" action from the browsers.

this is caused by a dependency of a `NetworkURLManager`'s `useEffect` hook. The dependency is always reassigned in each render, therefore, triggering the hook.