### PR TITLE
fix: optimizer values comparisons

### DIFF
--- a/src/components/Boost/Optimizer.tsx
+++ b/src/components/Boost/Optimizer.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { OptimizerBody } from './OptimizerBody';
 import { StoreContext } from '../../mobx/store-context';
 import { StakeInformation } from './StakeInformation';
-import { OptimizerHeader } from './OptimizerHeader';
+import OptimizerHeader from './OptimizerHeader';
 import { formatWithoutExtraZeros } from '../../mobx/utils/helpers';
 import { BoostRank } from '../../mobx/model/boost/leaderboard-rank';
 import { calculateNativeToMatchRank } from '../../utils/boost-ranks';

--- a/src/components/Boost/OptimizerHeader.tsx
+++ b/src/components/Boost/OptimizerHeader.tsx
@@ -14,7 +14,7 @@ const StyledInfoIcon = styled(InfoIcon)(({ theme }) => ({
 	color: 'rgba(255, 255, 255, 0.3)',
 }));
 
-const useMultiplierStyles = (currentStakeRatio: number, accountStakeRatio = 0) => {
+const useStakeRatioClasses = (currentStakeRatio: number, accountStakeRatio = 0) => {
 	return makeStyles((theme) => {
 		if (!isValidCalculatedValue(currentStakeRatio) || !isValidCalculatedValue(accountStakeRatio)) {
 			return {
@@ -74,7 +74,7 @@ const OptimizerHeader = ({ stakeRatio, onReset }: Props): JSX.Element => {
 	const theme = useTheme();
 	const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 	const accountStakeRatio = accountDetails ? accountDetails.nativeBalance / accountDetails.nonNativeBalance : 0;
-	const boostClasses = useMultiplierStyles(stakeRatio, accountStakeRatio)();
+	const boostClasses = useStakeRatioClasses(stakeRatio, accountStakeRatio)();
 	const currentBoost = calculateUserBoost(stakeRatio);
 	return (
 		<Grid container spacing={isMobile ? 2 : 0} className={classes.header} alignItems="center">

--- a/src/components/Boost/OptimizerHeader.tsx
+++ b/src/components/Boost/OptimizerHeader.tsx
@@ -1,19 +1,22 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Button, Grid, Tooltip, Typography, useMediaQuery, useTheme } from '@material-ui/core';
 import InfoIcon from '@material-ui/icons/Info';
 import { makeStyles, styled } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import { getColorFromComparison } from './utils';
-import { calculateUserBoost, isValidStakeRatio } from '../../utils/boost-ranks';
+import { calculateUserBoost } from '../../utils/boost-ranks';
+import { observer } from 'mobx-react-lite';
+import { StoreContext } from '../../mobx/store-context';
+import { isValidCalculatedValue, roundWithPrecision } from '../../utils/componentHelpers';
 
 const StyledInfoIcon = styled(InfoIcon)(({ theme }) => ({
 	marginLeft: theme.spacing(1),
 	color: 'rgba(255, 255, 255, 0.3)',
 }));
 
-const useMultiplierStyles = (currentMultiplier: number, accountMultiplier = 0) => {
+const useMultiplierStyles = (currentStakeRatio: number, accountStakeRatio = 0) => {
 	return makeStyles((theme) => {
-		if (!isValidStakeRatio(currentMultiplier) || !isValidStakeRatio(accountMultiplier)) {
+		if (!isValidCalculatedValue(currentStakeRatio) || !isValidCalculatedValue(accountStakeRatio)) {
 			return {
 				fontColor: {
 					color: theme.palette.text.primary,
@@ -24,8 +27,8 @@ const useMultiplierStyles = (currentMultiplier: number, accountMultiplier = 0) =
 		return {
 			fontColor: {
 				color: getColorFromComparison({
-					toCompareValue: currentMultiplier,
-					toBeComparedValue: accountMultiplier,
+					toCompareValue: roundWithPrecision(currentStakeRatio, 4),
+					toBeComparedValue: roundWithPrecision(accountStakeRatio, 4),
 					greaterCaseColor: '#74D189',
 					lessCaseColor: theme.palette.error.main,
 					defaultColor: theme.palette.text.primary,
@@ -63,12 +66,16 @@ interface Props {
 	onReset: () => void;
 }
 
-export const OptimizerHeader = ({ stakeRatio, onReset }: Props): JSX.Element => {
+const OptimizerHeader = ({ stakeRatio, onReset }: Props): JSX.Element => {
+	const {
+		user: { accountDetails },
+	} = useContext(StoreContext);
 	const classes = useStyles();
 	const theme = useTheme();
 	const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-	const userBoost = calculateUserBoost(stakeRatio);
-	const boostClasses = useMultiplierStyles(stakeRatio, userBoost)();
+	const accountStakeRatio = accountDetails ? accountDetails.nativeBalance / accountDetails.nonNativeBalance : 0;
+	const boostClasses = useMultiplierStyles(stakeRatio, accountStakeRatio)();
+	const currentBoost = calculateUserBoost(stakeRatio);
 	return (
 		<Grid container spacing={isMobile ? 2 : 0} className={classes.header} alignItems="center">
 			<Grid item className={classes.boostSectionContainer}>
@@ -76,7 +83,7 @@ export const OptimizerHeader = ({ stakeRatio, onReset }: Props): JSX.Element => 
 					Boost:
 				</Typography>
 				<Typography display="inline" className={clsx(classes.boostValue, boostClasses.fontColor)}>
-					{`${userBoost}x`}
+					{`${currentBoost}x`}
 				</Typography>
 				<Tooltip
 					enterTouchDelay={0}
@@ -98,3 +105,5 @@ export const OptimizerHeader = ({ stakeRatio, onReset }: Props): JSX.Element => 
 		</Grid>
 	);
 };
+
+export default observer(OptimizerHeader);

--- a/src/components/Boost/StakeInformation.tsx
+++ b/src/components/Boost/StakeInformation.tsx
@@ -5,9 +5,10 @@ import { observer } from 'mobx-react-lite';
 import { calculateUserBoost, getHighestRankFromStakeRatio } from '../../utils/boost-ranks';
 import { RankList } from './RankList';
 import { StoreContext } from '../../mobx/store-context';
-import { MIN_BOOST_RANK } from '../../config/system/boost-ranks';
+import { MIN_BOOST, MIN_BOOST_RANK } from '../../config/system/boost-ranks';
 import { StakeInformationHeader } from './StakeInformationHeader';
 import { BoostRank } from '../../mobx/model/boost/leaderboard-rank';
+import { isValidCalculatedValue } from '../../utils/componentHelpers';
 
 const useStyles = makeStyles((theme) => ({
 	root: {
@@ -46,8 +47,6 @@ const useStyles = makeStyles((theme) => ({
 	},
 }));
 
-const isValidCalculatedValue = (value: number) => isFinite(value) && !isNaN(value);
-
 interface Props {
 	native?: string;
 	nonNative?: string;
@@ -76,8 +75,8 @@ export const StakeInformation = observer(({ native, nonNative, onRankClick }: Pr
 	const accountStakeRatio = isValidAccountRatio ? calculatedAccountRatio : MIN_BOOST_RANK.stakeRatioBoundary;
 
 	const currentRank = getHighestRankFromStakeRatio(stakeRatio);
-	const userBoost = isValidStakeRatio ? calculateUserBoost(calculatedStakeRatio) : 0;
-	const accountBoost = isValidAccountRatio ? calculateUserBoost(calculatedAccountRatio) : 0;
+	const userBoost = isValidStakeRatio ? calculateUserBoost(calculatedStakeRatio) : MIN_BOOST;
+	const accountBoost = isValidAccountRatio ? calculateUserBoost(calculatedAccountRatio) : MIN_BOOST;
 
 	return (
 		<Grid container component={Paper} className={classes.root}>

--- a/src/components/Boost/StakeInformationHeader.tsx
+++ b/src/components/Boost/StakeInformationHeader.tsx
@@ -6,10 +6,11 @@ import { makeStyles } from '@material-ui/core/styles';
 import { getColorFromComparison } from './utils';
 import { BoostRank } from '../../mobx/model/boost/leaderboard-rank';
 import { Skeleton } from '@material-ui/lab';
+import { isValidCalculatedValue } from '../../utils/componentHelpers';
 
 const useComparedValuesStyles = (currentRatio: number, accountRatio: number) => {
 	return makeStyles((theme) => {
-		if (isNaN(currentRatio) || isNaN(accountRatio)) {
+		if (!isValidCalculatedValue(currentRatio) || !isValidCalculatedValue(accountRatio)) {
 			return {
 				fontColor: {
 					color: theme.palette.text.primary,

--- a/src/config/system/boost-ranks.ts
+++ b/src/config/system/boost-ranks.ts
@@ -1,5 +1,6 @@
 import { BoostRank } from '../../mobx/model/boost/leaderboard-rank';
 import { BadgerType } from '@badger-dao/sdk';
+import { calculateUserBoost } from '../../utils/boost-ranks';
 
 export const BOOST_RANKS: BoostRank[] = [
 	{
@@ -30,8 +31,9 @@ export const BOOST_RANKS: BoostRank[] = [
 ];
 
 export const MIN_BOOST_RANK = BOOST_RANKS[0];
-
+export const MIN_BOOST = calculateUserBoost(MIN_BOOST_RANK.stakeRatioBoundary);
 export const MAX_BOOST_RANK = BOOST_RANKS[BOOST_RANKS.length - 1];
+export const MAX_BOOST = calculateUserBoost(MAX_BOOST_RANK.stakeRatioBoundary);
 
 export const BADGER_TYPE_BOOSTS: Record<BadgerType, BoostRank> = {
 	[BadgerType.Basic]: BOOST_RANKS[0],
@@ -40,5 +42,3 @@ export const BADGER_TYPE_BOOSTS: Record<BadgerType, BoostRank> = {
 	[BadgerType.Hyper]: BOOST_RANKS[3],
 	[BadgerType.Frenzy]: BOOST_RANKS[4],
 };
-
-export const MAX_BOOST = 3000;

--- a/src/config/system/boost-ranks.ts
+++ b/src/config/system/boost-ranks.ts
@@ -1,6 +1,5 @@
 import { BoostRank } from '../../mobx/model/boost/leaderboard-rank';
 import { BadgerType } from '@badger-dao/sdk';
-import { calculateUserBoost } from '../../utils/boost-ranks';
 
 export const BOOST_RANKS: BoostRank[] = [
 	{
@@ -31,9 +30,9 @@ export const BOOST_RANKS: BoostRank[] = [
 ];
 
 export const MIN_BOOST_RANK = BOOST_RANKS[0];
-export const MIN_BOOST = calculateUserBoost(MIN_BOOST_RANK.stakeRatioBoundary);
+export const MIN_BOOST = 1;
 export const MAX_BOOST_RANK = BOOST_RANKS[BOOST_RANKS.length - 1];
-export const MAX_BOOST = calculateUserBoost(MAX_BOOST_RANK.stakeRatioBoundary);
+export const MAX_BOOST = 3000;
 
 export const BADGER_TYPE_BOOSTS: Record<BadgerType, BoostRank> = {
 	[BadgerType.Basic]: BOOST_RANKS[0],

--- a/src/tests/boost-optimizer/__snapshots__/Optimizer.test.tsx.snap
+++ b/src/tests/boost-optimizer/__snapshots__/Optimizer.test.tsx.snap
@@ -1116,7 +1116,7 @@ exports[`Boost Optimizer can decrease balances through the increase button 1`] =
                 <p
                   class="MuiTypography-root-143 makeStyles-informationValue-326 makeStyles-fontColor-328 MuiTypography-body1-145"
                 >
-                  0
+                  1
                   x
                 </p>
               </div>
@@ -2576,7 +2576,7 @@ exports[`Boost Optimizer can jump to rank 1`] = `
                 <p
                   class="MuiTypography-root-143 makeStyles-informationValue-326 makeStyles-fontColor-383 MuiTypography-body1-145"
                 >
-                  0
+                  1
                   x
                 </p>
               </div>
@@ -3303,7 +3303,7 @@ exports[`Boost Optimizer displays correct information 1`] = `
                 <p
                   class="MuiTypography-root-143 makeStyles-informationValue-326 makeStyles-fontColor-328 MuiTypography-body1-145"
                 >
-                  0
+                  1
                   x
                 </p>
               </div>
@@ -4022,7 +4022,7 @@ exports[`Boost Optimizer shows empty non native message 1`] = `
                 <p
                   class="MuiTypography-root-143 makeStyles-informationValue-326 makeStyles-fontColor-383 MuiTypography-body1-145"
                 >
-                  0
+                  1
                   x
                 </p>
               </div>
@@ -4732,7 +4732,7 @@ exports[`Boost Optimizer supports no wallet mode 1`] = `
                 <p
                   class="MuiTypography-root-143 makeStyles-informationValue-326 makeStyles-fontColor-328 MuiTypography-body1-145"
                 >
-                  0
+                  1
                   x
                 </p>
               </div>

--- a/src/utils/boost-ranks.ts
+++ b/src/utils/boost-ranks.ts
@@ -1,5 +1,5 @@
 import { BoostRank } from '../mobx/model/boost/leaderboard-rank';
-import { BOOST_RANKS, MAX_BOOST_RANK, MIN_BOOST_RANK } from '../config/system/boost-ranks';
+import { BOOST_RANKS, MAX_BOOST_RANK, MIN_BOOST, MIN_BOOST_RANK } from '../config/system/boost-ranks';
 import { restrictToRange } from './componentHelpers';
 
 /**
@@ -62,7 +62,7 @@ export const getNextBoostRank = (currentRank: BoostRank): BoostRank | undefined 
 // implementation of the boost rank system: https://github.com/Badger-Finance/badger-rewards/blob/main/rewards/boost/calc_boost.py#L56
 export const calculateUserBoost = (stakeRatio: number): number => {
 	if (stakeRatio === 0) {
-		return 1;
+		return MIN_BOOST;
 	}
 
 	if (stakeRatio <= 1) {

--- a/src/utils/componentHelpers.ts
+++ b/src/utils/componentHelpers.ts
@@ -110,3 +110,5 @@ export function getTokenIconPath(token: Token): string {
 	const fileName = token.symbol.replaceAll('/', '-');
 	return `/assets/icons/${fileName.toLowerCase()}.svg`;
 }
+
+export const isValidCalculatedValue = (value: number) => isFinite(value) && !isNaN(value);


### PR DESCRIPTION
- in the optimizer header the user boost was being compared with the stake ratio to get the text color of the boost
- the default value of the user boost was `0` instead of the actual minimum `1`