### PR TITLE
chore: replace invalid values with zero

### DIFF
--- a/src/components-v2/ibbtc-vault/BalanceInput.tsx
+++ b/src/components-v2/ibbtc-vault/BalanceInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { Box, ButtonBase, Divider, Grid, TextField, Typography } from '@material-ui/core';
 import { inCurrency } from '../../mobx/utils/helpers';
 import { useNumericInput } from '../../utils/useNumericInput';
@@ -37,7 +37,8 @@ const BalanceInput = ({ tokenBalance, onChange }: Props): JSX.Element => {
 
 	const handleInputChange = (amount: string) => {
 		setInputValue(amount);
-		onChange(TokenBalance.fromBalance(tokenBalance, amount || '0'));
+		const inputBalance = TokenBalance.fromBalance(tokenBalance, amount || '0');
+		onChange(inputBalance.tokenBalance.isNaN() ? TokenBalance.fromBalance(tokenBalance, '0') : inputBalance);
 	};
 
 	const handleApplyPercentage = (percentage: number) => {

--- a/src/components-v2/ibbtc-vault/IbbtcVaultDepositDialog.tsx
+++ b/src/components-v2/ibbtc-vault/IbbtcVaultDepositDialog.tsx
@@ -31,7 +31,6 @@ import { sendContractMethod } from '../../mobx/utils/web3';
 import { VaultModalProps } from '../common/dialogs/VaultDeposit';
 import { Loader } from '../../components/Loader';
 import SlippageMessage from './SlippageMessage';
-import { debounce } from '../../utils/componentHelpers';
 import { ReportProblem } from '@material-ui/icons';
 import { BalanceNamespace } from '../../web3/config/namespaces';
 import clsx from 'clsx';
@@ -192,38 +191,35 @@ const IbbtcVaultDepositDialog = ({ open = false, onClose }: VaultModalProps): JS
 		setExpectedSlippage(calculatedSlippage);
 	};
 
-	const handleDepositBalanceChange = useCallback(
-		debounce(200, async (tokenBalance: TokenBalance, index: number) => {
-			const balances = [...multiTokenDepositBalances];
-			balances[index] = tokenBalance;
+	const handleDepositBalanceChange = async (tokenBalance: TokenBalance, index: number) => {
+		const balances = [...multiTokenDepositBalances];
+		balances[index] = tokenBalance;
+		const totalDeposit = balances.reduce((total, balance) => total.plus(balance.tokenBalance), new BigNumber(0));
 
-			const totalDeposit = balances.reduce(
-				(total, balance) => total.plus(balance.tokenBalance),
-				new BigNumber(0),
-			);
-
-			if (totalDeposit.isZero()) {
-				resetCalculatedInformation();
-				return;
-			}
-
-			const [calculatedMint, expectedAmount] = await getCalculations(balances);
-			// formula is: slippage = [(expectedAmount - calculatedMint) * 100] / expectedAmount
-			const calculatedSlippage = expectedAmount.minus(calculatedMint).multipliedBy(100).dividedBy(expectedAmount);
-			const minOut = expectedAmount.multipliedBy(1 - slippage / 100);
-
-			if (userLpTokenBalance) {
-				setMinPoolTokens(TokenBalance.fromBigNumber(userLpTokenBalance, minOut));
-				setExpectedPoolTokens(TokenBalance.fromBigNumber(userLpTokenBalance, calculatedMint));
-			}
-
-			// this will protect users from submitting tx that will be reverted because of slippage
-			setSlippageRevertProtected(calculatedMint.isLessThan(minOut));
-			setExpectedSlippage(calculatedSlippage);
+		if (totalDeposit.isZero()) {
 			setMultiTokenDepositBalances(balances);
-		}),
-		[getCalculations, resetCalculatedInformation, userLpTokenBalance, multiTokenDepositBalances, slippage],
-	);
+			setSlippageRevertProtected(false);
+			setExpectedSlippage(undefined);
+			setExpectedPoolTokens(undefined);
+			setMinPoolTokens(undefined);
+			return;
+		}
+
+		const [calculatedMint, expectedAmount] = await getCalculations(balances);
+		// formula: slippage = [(expectedAmount - calculatedMint) * 100] / expectedAmount
+		const calculatedSlippage = expectedAmount.minus(calculatedMint).multipliedBy(100).dividedBy(expectedAmount);
+		const minOut = expectedAmount.multipliedBy(1 - slippage / 100);
+
+		if (userLpTokenBalance) {
+			setMinPoolTokens(TokenBalance.fromBigNumber(userLpTokenBalance, minOut));
+			setExpectedPoolTokens(TokenBalance.fromBigNumber(userLpTokenBalance, calculatedMint));
+		}
+
+		// this will protect users from submitting tx that will be reverted because of slippage
+		setSlippageRevertProtected(calculatedMint.isLessThan(minOut));
+		setExpectedSlippage(calculatedSlippage);
+		setMultiTokenDepositBalances(balances);
+	};
 
 	const handleLpTokenDeposit = async () => {
 		if (!lpTokenDepositBalance || !userLpTokenBalance || !lpVault || !lpBadgerVault) {

--- a/src/components-v2/ibbtc-vault/IbbtcVaultDepositDialog.tsx
+++ b/src/components-v2/ibbtc-vault/IbbtcVaultDepositDialog.tsx
@@ -153,8 +153,11 @@ const IbbtcVaultDepositDialog = ({ open = false, onClose }: VaultModalProps): JS
 		async (balances: TokenBalance[]): Promise<BigNumber[]> => {
 			const web3 = new Web3(onboard.wallet?.provider);
 			const ibbtcVaultPeak = new web3.eth.Contract(IbbtcVaultZapAbi as AbiItem[], mainnetDeploy.ibbtcVaultZap);
+			const validBalances = balances.map((balance) =>
+				balance.tokenBalance.isNaN() ? TokenBalance.fromBalance(balance, '0') : balance,
+			);
 
-			const depositAmounts = balances.map((balance) => toHex(balance.tokenBalance));
+			const depositAmounts = validBalances.map((balance) => toHex(balance.tokenBalance));
 
 			const [calculatedMint, expectedAmount] = await Promise.all([
 				new BigNumber(await ibbtcVaultPeak.methods.calcMint(depositAmounts, false).call()),

--- a/src/components-v2/ibbtc-vault/IbbtcVaultDepositDialog.tsx
+++ b/src/components-v2/ibbtc-vault/IbbtcVaultDepositDialog.tsx
@@ -153,11 +153,7 @@ const IbbtcVaultDepositDialog = ({ open = false, onClose }: VaultModalProps): JS
 		async (balances: TokenBalance[]): Promise<BigNumber[]> => {
 			const web3 = new Web3(onboard.wallet?.provider);
 			const ibbtcVaultPeak = new web3.eth.Contract(IbbtcVaultZapAbi as AbiItem[], mainnetDeploy.ibbtcVaultZap);
-			const validBalances = balances.map((balance) =>
-				balance.tokenBalance.isNaN() ? TokenBalance.fromBalance(balance, '0') : balance,
-			);
-
-			const depositAmounts = validBalances.map((balance) => toHex(balance.tokenBalance));
+			const depositAmounts = balances.map((balance) => toHex(balance.tokenBalance));
 
 			const [calculatedMint, expectedAmount] = await Promise.all([
 				new BigNumber(await ibbtcVaultPeak.methods.calcMint(depositAmounts, false).call()),


### PR DESCRIPTION
### changelog:

- remove the debounce in the inputs.
- found that when the input is an `.` the balances are transformed to `NaN`. Incorrect balances are now replaced with zero.
- when the inputs are zero/empty `resetCalculatedInformation()` was being called which resets the input balances to the wallet balances. This behavior is incorrect and should be executed only when switching between tabs. This scenario now is handled to execute the same actions as `resetCalculatedInformation` but without resetting wallet balances.