### PR TITLE
chore: remove unused interface

### DIFF
--- a/src/components-v2/landing/DisabledSettListItem.tsx
+++ b/src/components-v2/landing/DisabledSettListItem.tsx
@@ -77,7 +77,6 @@ const useStyles = makeStyles((theme) => ({
 
 interface DisabledSettListItemProps extends SettListItemProps {
 	apy: number | string;
-	tooltip: JSX.Element;
 	displayName: string;
 	disabledTooltip: string;
 }
@@ -85,7 +84,7 @@ interface DisabledSettListItemProps extends SettListItemProps {
 const DisabledSettListItem = (props: DisabledSettListItemProps): JSX.Element => {
 	const classes = useStyles();
 
-	const { apy, tooltip, displayName, sett, balance, balanceValue, currency, disabledTooltip, onOpen } = props;
+	const { apy, displayName, sett, balance, balanceValue, currency, disabledTooltip, onOpen } = props;
 
 	const displayValue = balanceValue ? balanceValue : usdToCurrency(new BigNumber(sett.value), currency);
 
@@ -166,11 +165,9 @@ const DisabledSettListItem = (props: DisabledSettListItemProps): JSX.Element => 
 						</Typography>
 					</Grid>
 					<Grid item xs={6} md={2} className={classes.centerGrid}>
-						<Tooltip enterDelay={0} leaveDelay={300} arrow placement="left" title={tooltip}>
-							<Typography style={{ cursor: 'default' }} variant="body1" color={'textPrimary'}>
-								{typeof apy === 'number' ? `${apy.toFixed(2)}%` : apy}
-							</Typography>
-						</Tooltip>
+						<Typography style={{ cursor: 'default' }} variant="body1" color={'textPrimary'}>
+							{typeof apy === 'number' ? `${apy.toFixed(2)}%` : apy}
+						</Typography>
 					</Grid>
 					{/* Intentionally Empty Grid Space */}
 					<Grid item xs={6} md={1} className={classes.desktopSpacer} />

--- a/src/mobx/model/account/account.ts
+++ b/src/mobx/model/account/account.ts
@@ -1,6 +1,5 @@
 import { AccountLimits } from './account-limits';
 import { SettBalance } from '../setts/sett-balance';
-import { BoostMultipliers } from '../boost/boost-multipliers';
 
 export interface Account {
 	id: string;
@@ -9,7 +8,6 @@ export interface Account {
 	stakeRatio: number;
 	nativeBalance: number;
 	nonNativeBalance: number;
-	multipliers: BoostMultipliers;
 	depositLimits: AccountLimits;
 	// currently unused below
 	value: number;

--- a/src/mobx/model/boost/boost-multipliers.ts
+++ b/src/mobx/model/boost/boost-multipliers.ts
@@ -1,3 +1,0 @@
-export interface BoostMultipliers {
-	[contract: string]: number;
-}

--- a/src/mobx/stores/rewardsStore.ts
+++ b/src/mobx/stores/rewardsStore.ts
@@ -129,7 +129,7 @@ class RewardsStore {
 		async (): Promise<void> => {
 			const { provider } = this.store.wallet;
 
-			if (this.loadingRewards) {
+			if (this.loadingRewards || !provider) {
 				return;
 			}
 			this.resetRewards();


### PR DESCRIPTION
# Summary

Remove legacy app multipliers reference, I am aware I gutted the APR. These users can check the normal app for it.