### PR TITLE
fix: handle empty non native balance

### DIFF
--- a/src/components/Boost/Optimizer.tsx
+++ b/src/components/Boost/Optimizer.tsx
@@ -10,6 +10,7 @@ import OptimizerHeader from './OptimizerHeader';
 import { formatWithoutExtraZeros } from '../../mobx/utils/helpers';
 import { BoostRank } from '../../mobx/model/boost/leaderboard-rank';
 import { calculateNativeToMatchRank } from '../../utils/boost-ranks';
+import { isValidCalculatedValue } from '../../utils/componentHelpers';
 
 const useStyles = makeStyles((theme) => ({
 	calculatorContainer: {
@@ -142,7 +143,7 @@ export const Optimizer = observer((): JSX.Element => {
 
 		setNative(formatWithoutExtraZeros(nativeBalance, 4));
 		setNonNative(formatWithoutExtraZeros(nonNativeBalance, 4));
-		setStakeRatio(stakeRatio);
+		setStakeRatio(isValidCalculatedValue(stakeRatio) ? stakeRatio : 0);
 	}, [accountDetails, wallet, wallet.address]);
 
 	return (

--- a/src/components/Boost/OptimizerHeader.tsx
+++ b/src/components/Boost/OptimizerHeader.tsx
@@ -47,6 +47,7 @@ const useStyles = makeStyles((theme) => ({
 	},
 	boostText: {
 		fontSize: theme.spacing(4),
+		fontWeight: 400,
 	},
 	boostValue: {
 		fontSize: theme.spacing(4),
@@ -79,11 +80,9 @@ const OptimizerHeader = ({ stakeRatio, onReset }: Props): JSX.Element => {
 	return (
 		<Grid container spacing={isMobile ? 2 : 0} className={classes.header} alignItems="center">
 			<Grid item className={classes.boostSectionContainer}>
-				<Typography display="inline" className={classes.boostText}>
+				<Typography display="inline" variant="h6" className={classes.boostText}>
 					Boost:
-				</Typography>
-				<Typography display="inline" className={clsx(classes.boostValue, boostClasses.fontColor)}>
-					{`${currentBoost}x`}
+					<span className={clsx(classes.boostValue, boostClasses.fontColor)}>{`${currentBoost}x`}</span>
 				</Typography>
 				<Tooltip
 					enterTouchDelay={0}

--- a/src/tests/boost-optimizer/Optimizer.test.tsx
+++ b/src/tests/boost-optimizer/Optimizer.test.tsx
@@ -19,21 +19,6 @@ describe('Boost Optimizer', () => {
 			address: '0xC26202cd0428276cC69017Df01137161f0102e55',
 			boost: 1,
 			boostRank: 123,
-			multipliers: {
-				'0x6dEf55d2e18486B9dDfaA075bc4e4EE0B28c1545': 0.6181384749194523,
-				'0xd04c48A53c111300aD41190D63681ed3dAd998eC': 0.5523543018519733,
-				'0xb9D076fDe463dbc9f915E5392F807315Bf940334': 0.5341201002772149,
-				'0xAf5A1DECfa95BAF63E0084a35c62592B774A2A87': 0.6045632751200407,
-				'0x758A43EE2BFf8230eeb784879CdcFF4828F2544D': 0.5165013357377896,
-				'0x4b92d19c11435614CD49Af1b589001b7c08cD4D5': 0.6028052092763515,
-				'0x8a8FFec8f4A0C8c9585Da95D9D97e8Cd6de273DE': 0.4548797589205743,
-				'0x8c76970747afd5398e958bDfadA4cf0B9FcA16c4': 0.41316829888029033,
-				'0x55912D0Cf83B75c492E761932ABc4DB4a5CB1b17': 0.4212673127531778,
-				'0xf349c0faA80fC1870306Ac093f75934078e28991': 0.41377994228689197,
-				'0x5Dce29e92b1b939F8E8C60DcF15BDE82A85be4a9': 0.3682893510950006,
-				'0xBE08Ef12e4a553666291E9fFC24fCCFd354F2Dd2': 0.419679575056266,
-				'0x53C8E199eb2Cb7c01543C137078a038937a68E40': 0.42187808912743524,
-			},
 			value: 0,
 			earnedValue: 0,
 			data: {},
@@ -43,7 +28,7 @@ describe('Boost Optimizer', () => {
 			stakeRatio: 20,
 			bveCvxBalance: 100,
 			nftBalance: 50,
-			rank: 0,
+			diggBalance: 0,
 		};
 
 		jest.spyOn(rankUtils, 'calculateUserBoost').mockReturnValue(1);
@@ -58,6 +43,30 @@ describe('Boost Optimizer', () => {
 		);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('handles zero non-native balance', () => {
+		store.user.accountDetails = {
+			address: '0xC26202cd0428276cC69017Df01137161f0102e55',
+			boost: 1,
+			boostRank: 123,
+			value: 0,
+			earnedValue: 0,
+			data: {},
+			claimableBalances: {},
+			nativeBalance: 1000,
+			nonNativeBalance: 0,
+			stakeRatio: 20,
+			bveCvxBalance: 100,
+			nftBalance: 50,
+			diggBalance: 0,
+		};
+		customRender(
+			<StoreProvider value={store}>
+				<Optimizer />
+			</StoreProvider>,
+		);
+		expect(screen.getByRole('heading', { name: 'Boost: 1x' })).toBeInTheDocument();
 	});
 
 	it('can change native and non native balances', () => {

--- a/src/tests/boost-optimizer/__snapshots__/Optimizer.test.tsx.snap
+++ b/src/tests/boost-optimizer/__snapshots__/Optimizer.test.tsx.snap
@@ -20,16 +20,16 @@ exports[`Boost Optimizer can jump to rank 1`] = `
             <div
               class="MuiGrid-root-6 makeStyles-boostSectionContainer-141 MuiGrid-item-8"
             >
-              <p
-                class="MuiTypography-root-143 makeStyles-boostText-138 MuiTypography-body1-145 MuiTypography-displayInline-171"
+              <h6
+                class="MuiTypography-root-143 makeStyles-boostText-138 MuiTypography-h6-153 MuiTypography-displayInline-171"
               >
                 Boost:
-              </p>
-              <p
-                class="MuiTypography-root-143 makeStyles-boostValue-139 makeStyles-fontColor-406 MuiTypography-body1-145 MuiTypography-displayInline-171"
-              >
-                1x
-              </p>
+                <span
+                  class="makeStyles-boostValue-139 makeStyles-fontColor-406"
+                >
+                  1x
+                </span>
+              </h6>
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root-186 memo-root-184 memo-root-185 MuiSvgIcon-colorPrimary-187"
@@ -764,16 +764,16 @@ exports[`Boost Optimizer displays correct information 1`] = `
             <div
               class="MuiGrid-root-6 makeStyles-boostSectionContainer-141 MuiGrid-item-8"
             >
-              <p
-                class="MuiTypography-root-143 makeStyles-boostText-138 MuiTypography-body1-145 MuiTypography-displayInline-171"
+              <h6
+                class="MuiTypography-root-143 makeStyles-boostText-138 MuiTypography-h6-153 MuiTypography-displayInline-171"
               >
                 Boost:
-              </p>
-              <p
-                class="MuiTypography-root-143 makeStyles-boostValue-139 makeStyles-fontColor-366 MuiTypography-body1-145 MuiTypography-displayInline-171"
-              >
-                1x
-              </p>
+                <span
+                  class="makeStyles-boostValue-139 makeStyles-fontColor-366"
+                >
+                  1x
+                </span>
+              </h6>
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root-186 memo-root-184 memo-root-185 MuiSvgIcon-colorPrimary-187"
@@ -1486,16 +1486,16 @@ exports[`Boost Optimizer supports no wallet mode 1`] = `
             <div
               class="MuiGrid-root-6 makeStyles-boostSectionContainer-141 MuiGrid-item-8"
             >
-              <p
-                class="MuiTypography-root-143 makeStyles-boostText-138 MuiTypography-body1-145 MuiTypography-displayInline-171"
+              <h6
+                class="MuiTypography-root-143 makeStyles-boostText-138 MuiTypography-h6-153 MuiTypography-displayInline-171"
               >
                 Boost:
-              </p>
-              <p
-                class="MuiTypography-root-143 makeStyles-boostValue-139 makeStyles-fontColor-142 MuiTypography-body1-145 MuiTypography-displayInline-171"
-              >
-                1x
-              </p>
+                <span
+                  class="makeStyles-boostValue-139 makeStyles-fontColor-142"
+                >
+                  1x
+                </span>
+              </h6>
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root-186 memo-root-184 memo-root-185 MuiSvgIcon-colorPrimary-187"


### PR DESCRIPTION
when the account has a zero nonnative balance, the initial stake ratio calculation:
```ts
stakeRatio = nativeBalance / nonNativeBalance;
```
results in either `Inifiny` or `NaN`