### PR TITLE
fix(bve-cvx): hook deposit and withdraw dialogs

### DIFF
--- a/src/components-v2/BveCvxPerformance/index.tsx
+++ b/src/components-v2/BveCvxPerformance/index.tsx
@@ -122,7 +122,7 @@ const BveCvxPerformance = ({ vault }: Props): JSX.Element => {
 						<SpecItem
 							name={
 								<Box component="span" display="flex" justifyContent="center" alignItems="center">
-									CVX Available for Withdraw
+									CVX Available for Withdrawal
 									<StyledHelpIcon onClick={() => setInfoDialogOpen(true)} />
 								</Box>
 							}

--- a/src/components-v2/BveCvxPerformance/index.tsx
+++ b/src/components-v2/BveCvxPerformance/index.tsx
@@ -122,7 +122,7 @@ const BveCvxPerformance = ({ vault }: Props): JSX.Element => {
 						<SpecItem
 							name={
 								<Box component="span" display="flex" justifyContent="center" alignItems="center">
-									CVX Withdrawable
+									CVX Available for Withdraw
 									<StyledHelpIcon onClick={() => setInfoDialogOpen(true)} />
 								</Box>
 							}

--- a/src/components-v2/BveCvxSpecs/index.tsx
+++ b/src/components-v2/BveCvxSpecs/index.tsx
@@ -71,7 +71,7 @@ const BveCvxSpecs = ({ vault }: Props): JSX.Element => {
 					<SpecItem
 						name={
 							<Box component="span" display="flex" justifyContent="center" alignItems="center">
-								CVX Withdrawable
+								CVX Available for Withdraw
 								<StyledHelpIcon onClick={() => setWithdrawInfoOpen(true)} />
 							</Box>
 						}

--- a/src/components-v2/BveCvxSpecs/index.tsx
+++ b/src/components-v2/BveCvxSpecs/index.tsx
@@ -71,7 +71,7 @@ const BveCvxSpecs = ({ vault }: Props): JSX.Element => {
 					<SpecItem
 						name={
 							<Box component="span" display="flex" justifyContent="center" alignItems="center">
-								CVX Available for Withdraw
+								CVX Available for Withdrawal
 								<StyledHelpIcon onClick={() => setWithdrawInfoOpen(true)} />
 							</Box>
 						}

--- a/src/components-v2/landing/VaultListItemMobile.tsx
+++ b/src/components-v2/landing/VaultListItemMobile.tsx
@@ -5,7 +5,6 @@ import { VaultDTO } from '@badger-dao/sdk';
 import VaultItemApr from './VaultItemApr';
 import CurrencyDisplay from '../common/CurrencyDisplay';
 import { useVaultInformation } from '../../hooks/useVaultInformation';
-import routes from '../../config/routes';
 import { StoreContext } from '../../mobx/store-context';
 import VaultListItemTags from '../VaultListItemTags';
 import VaultLogo from './VaultLogo';
@@ -29,11 +28,11 @@ interface Props {
 
 const VaultListItemMobile = ({ vault }: Props): JSX.Element => {
 	const classes = useStyles();
-	const { router, vaults } = useContext(StoreContext);
+	const { vaults } = useContext(StoreContext);
 	const { vaultBoost, depositBalanceDisplay } = useVaultInformation(vault);
 
 	const goToVaultDetail = async () => {
-		await router.goTo(routes.vaultDetail, { vaultName: vaults.getSlug(vault.vaultToken) });
+		await vaults.navigateToVaultDetail(vault);
 	};
 
 	const handleStatusClick = (event: MouseEvent<HTMLElement>) => {

--- a/src/components-v2/vault-detail/MainContent.tsx
+++ b/src/components-v2/vault-detail/MainContent.tsx
@@ -36,7 +36,7 @@ interface Props {
 }
 
 export const MainContent = observer(({ vault }: Props): JSX.Element => {
-	const { user, wallet } = React.useContext(StoreContext);
+	const { user, wallet, vaultDetail } = React.useContext(StoreContext);
 
 	const classes = useStyles();
 	const userData = user.accountDetails?.data[vault.vaultToken] ?? defaultVaultBalance(vault);
@@ -45,7 +45,12 @@ export const MainContent = observer(({ vault }: Props): JSX.Element => {
 		<Grid container className={classes.content}>
 			{wallet.isConnected && (
 				<Grid container className={classes.holdingsContainer}>
-					<Holdings vault={vault} userData={userData} />
+					<Holdings
+						vault={vault}
+						userData={userData}
+						onWithdrawClick={() => vaultDetail.toggleWithdrawDialog()}
+						onDepositClick={() => vaultDetail.toggleDepositDialog()}
+					/>
 				</Grid>
 			)}
 			<Grid container spacing={1}>

--- a/src/components-v2/vault-detail/VaultDetail.tsx
+++ b/src/components-v2/vault-detail/VaultDetail.tsx
@@ -85,7 +85,13 @@ export const VaultDetail = observer((): JSX.Element => {
 					</>
 				)}
 			</Container>
-			<MobileStickyActionButtons />
+			{vault && (
+				<MobileStickyActionButtons
+					vault={vault}
+					onDepositClick={() => vaultDetail.toggleDepositDialog()}
+					onWithdrawClick={() => vaultDetail.toggleWithdrawDialog()}
+				/>
+			)}
 			{vault && badgerVault && (
 				<>
 					<DepositWidget

--- a/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
+++ b/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
@@ -3,6 +3,8 @@ import { Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import { StoreContext } from '../../../mobx/store-context';
+import { VaultDTO } from '@badger-dao/sdk';
+import { observer } from 'mobx-react-lite';
 
 const useStyles = makeStyles((theme) => ({
 	root: {
@@ -18,10 +20,17 @@ const useStyles = makeStyles((theme) => ({
 	},
 }));
 
-export const MobileStickyActionButtons = (): JSX.Element => {
+interface Props {
+	vault: VaultDTO;
+	onDepositClick: () => void;
+	onWithdrawClick: () => void;
+}
+
+export const MobileStickyActionButtons = observer(({ vault, onDepositClick, onWithdrawClick }: Props): JSX.Element => {
 	const classes = useStyles();
-	const { vaultDetail } = React.useContext(StoreContext);
-	const { canUserDeposit, canUserWithdraw } = vaultDetail;
+	const { vaults, wallet } = React.useContext(StoreContext);
+	const canUserDeposit = wallet.isConnected ? vaults.canUserDeposit(vault) : false;
+	const canUserWithdraw = vaults.canUserWithdraw(vault);
 
 	return (
 		<div className={classes.root}>
@@ -32,7 +41,7 @@ export const MobileStickyActionButtons = (): JSX.Element => {
 						color="primary"
 						variant={canUserDeposit ? 'contained' : 'outlined'}
 						disabled={!canUserDeposit}
-						onClick={() => vaultDetail.toggleDepositDialog()}
+						onClick={onDepositClick}
 					>
 						Deposit
 					</VaultActionButton>
@@ -43,7 +52,7 @@ export const MobileStickyActionButtons = (): JSX.Element => {
 						variant="outlined"
 						fullWidth
 						disabled={!canUserWithdraw}
-						onClick={() => vaultDetail.toggleWithdrawDialog()}
+						onClick={onWithdrawClick}
 					>
 						Withdraw
 					</VaultActionButton>
@@ -51,4 +60,4 @@ export const MobileStickyActionButtons = (): JSX.Element => {
 			</Grid>
 		</div>
 	);
-};
+});

--- a/src/components-v2/vault-detail/holdings/Holdings.tsx
+++ b/src/components-v2/vault-detail/holdings/Holdings.tsx
@@ -26,19 +26,20 @@ const useStyles = makeStyles((theme) => ({
 interface Props {
 	vault: VaultDTO;
 	userData: VaultData;
+	onDepositClick: () => void;
+	onWithdrawClick: () => void;
 }
 
-export const Holdings = observer(({ userData, vault }: Props): JSX.Element | null => {
-	const { user, vaults } = React.useContext(StoreContext);
+export const Holdings = observer(({ userData, vault, onDepositClick, onWithdrawClick }: Props): JSX.Element | null => {
+	const { vaults } = React.useContext(StoreContext);
 	const isMediumSizeScreen = useMediaQuery(useTheme().breakpoints.up('sm'));
 	const classes = useStyles();
-	const canDeposit = user.onGuestList(vault);
 	const { depositBalance } = useVaultInformation(vault);
 
 	if (depositBalance.tokenBalance.eq(0)) {
 		return (
 			<Grid container>
-				<NoHoldings vault={vault} />
+				<NoHoldings vault={vault} onDepositClick={onDepositClick} />
 			</Grid>
 		);
 	}
@@ -73,7 +74,11 @@ export const Holdings = observer(({ userData, vault }: Props): JSX.Element | nul
 				)}
 				{isMediumSizeScreen && (
 					<Grid item xs={12} sm>
-						<HoldingsActionButtons canDeposit={canDeposit} />
+						<HoldingsActionButtons
+							vault={vault}
+							onDepositClick={onDepositClick}
+							onWithdrawClick={onWithdrawClick}
+						/>
 					</Grid>
 				)}
 			</Grid>

--- a/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import { makeStyles } from '@material-ui/core/styles';
 import { StoreContext } from '../../../mobx/store-context';
+import { VaultDTO } from '@badger-dao/sdk';
 
 const useStyles = makeStyles((theme) => ({
 	root: {
@@ -19,24 +20,27 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 interface Props {
-	canDeposit: boolean;
+	vault: VaultDTO;
+	onDepositClick: () => void;
+	onWithdrawClick: () => void;
 }
 
-export const HoldingsActionButtons = ({ canDeposit }: Props): JSX.Element => {
-	const { vaultDetail } = React.useContext(StoreContext);
-	const { canUserDeposit, canUserWithdraw } = vaultDetail;
+export const HoldingsActionButtons = ({ vault, onDepositClick, onWithdrawClick }: Props): JSX.Element => {
+	const { vaults, wallet } = React.useContext(StoreContext);
+	const canUserDeposit = wallet.isConnected ? vaults.canUserDeposit(vault) : false;
+	const canUserWithdraw = vaults.canUserWithdraw(vault);
 	const classes = useStyles();
 
 	return (
 		<div className={classes.root}>
-			{canDeposit && (
+			{canUserDeposit && (
 				<VaultActionButton
 					fullWidth
 					className={classes.deposit}
 					color="primary"
 					variant={canUserDeposit ? 'contained' : 'outlined'}
 					disabled={!canUserDeposit}
-					onClick={() => vaultDetail.toggleDepositDialog()}
+					onClick={onDepositClick}
 				>
 					Deposit
 				</VaultActionButton>
@@ -47,7 +51,7 @@ export const HoldingsActionButtons = ({ canDeposit }: Props): JSX.Element => {
 				color="primary"
 				variant="outlined"
 				disabled={!canUserWithdraw}
-				onClick={() => vaultDetail.toggleWithdrawDialog()}
+				onClick={onWithdrawClick}
 			>
 				Withdraw
 			</VaultActionButton>

--- a/src/components-v2/vault-detail/holdings/NoHoldings.tsx
+++ b/src/components-v2/vault-detail/holdings/NoHoldings.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Grid, Paper, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { VaultActionButton } from '../../common/VaultActionButtons';
-import { BadgerVault } from '../../../mobx/model/vaults/badger-vault';
 import { observer } from 'mobx-react-lite';
 import { StoreContext } from '../../../mobx/store-context';
 import DepositInfo from './DepositInfo';
@@ -30,11 +29,12 @@ const useStyles = makeStyles((theme) => ({
 
 interface Props {
 	vault: VaultDTO;
+	onDepositClick: () => void;
 }
 
-export const NoHoldings = observer(({ vault }: Props): JSX.Element | null => {
+export const NoHoldings = observer(({ vault, onDepositClick }: Props): JSX.Element | null => {
 	const store = React.useContext(StoreContext);
-	const { network: networkStore, vaultDetail, user } = store;
+	const { network: networkStore, user } = store;
 	const { network } = networkStore;
 	const classes = useStyles();
 
@@ -50,12 +50,7 @@ export const NoHoldings = observer(({ vault }: Props): JSX.Element | null => {
 				<DepositInfo strategy={strategy} />
 			</Grid>
 			<Grid item xs={12} sm className={classes.depositContainer}>
-				<VaultActionButton
-					color="primary"
-					variant="contained"
-					fullWidth
-					onClick={() => vaultDetail.toggleDepositDialog()}
-				>
+				<VaultActionButton color="primary" variant="contained" fullWidth onClick={onDepositClick}>
 					Deposit
 				</VaultActionButton>
 			</Grid>

--- a/src/mobx/stores/VaultDetail.store.ts
+++ b/src/mobx/stores/VaultDetail.store.ts
@@ -1,8 +1,6 @@
 import { RootStore } from '../RootStore';
 import { action, extendObservable, observe } from 'mobx';
-import { BalanceNamespace } from 'web3/config/namespaces';
 import { VaultDTO } from '@badger-dao/sdk';
-import { ETH_DEPLOY } from '../model/network/eth.network';
 
 export class VaultDetailStore {
 	private readonly store: RootStore;
@@ -58,35 +56,15 @@ export class VaultDetailStore {
 	}
 
 	get canUserWithdraw(): boolean {
-		if (!this.searchedVault) {
-			return false;
-		}
+		if (!this.searchedVault) return false;
 		const vault = this.store.vaults.getVault(this.searchedVault.vaultToken);
-		const vaultDefinition = vault ? this.store.vaults.getVaultDefinition(vault) : undefined;
-
-		if (!vaultDefinition) {
-			return false;
-		}
-
-		const openBalance = this.store.user.getBalance(BalanceNamespace.Vault, vaultDefinition).balance;
-		const guardedBalance = this.store.user.getBalance(BalanceNamespace.GuardedVault, vaultDefinition).balance;
-
-		return openBalance.plus(guardedBalance).gt(0);
+		if (!vault) return false;
+		return this.store.vaults.canUserWithdraw(vault);
 	}
 
 	get canUserDeposit(): boolean {
-		const isConnected = this.store.wallet.isConnected;
-
-		if (!isConnected || !this.searchedVault) {
-			return false;
-		}
-
-		// rem badger does not support deposit
-		if (this.searchedVault.vaultToken === ETH_DEPLOY.sett_system.vaults['native.rembadger']) {
-			return false;
-		}
-
-		return this.store.user.onGuestList(this.searchedVault);
+		if (!this.searchedVault) return false;
+		return this.store.vaults.canUserDeposit(this.searchedVault);
 	}
 
 	toggleDepositDialog(): void {

--- a/src/mobx/stores/VaultStore.ts
+++ b/src/mobx/stores/VaultStore.ts
@@ -32,6 +32,8 @@ import { getUserVaultBoost } from '../../utils/componentHelpers';
 
 import mainnetDeploy from '../../config/deployments/mainnet.json';
 import routes from '../../config/routes';
+import { BalanceNamespace } from '../../web3/config/namespaces';
+import { ETH_DEPLOY } from '../model/network/eth.network';
 
 export default class VaultStore {
 	private store!: RootStore;
@@ -358,6 +360,27 @@ export default class VaultStore {
 			this.protocolSummaryCache[chain] = null;
 		}
 	});
+
+	canUserWithdraw(vault: VaultDTO): boolean {
+		const vaultDefinition = vault ? this.store.vaults.getVaultDefinition(vault) : undefined;
+
+		if (!vaultDefinition) {
+			return false;
+		}
+
+		const openBalance = this.store.user.getBalance(BalanceNamespace.Vault, vaultDefinition).balance;
+		const guardedBalance = this.store.user.getBalance(BalanceNamespace.GuardedVault, vaultDefinition).balance;
+		return openBalance.plus(guardedBalance).gt(0);
+	}
+
+	canUserDeposit(vault: VaultDTO): boolean {
+		// rem badger does not support deposit
+		if (vault.vaultToken === ETH_DEPLOY.sett_system.vaults['native.rembadger']) {
+			return false;
+		}
+
+		return this.store.user.onGuestList(vault);
+	}
 
 	updateAvailableBalance = action((returnContext: ContractCallReturnContext): void => {
 		const { prices } = this.store;

--- a/src/pages/BveCvxInfluence.tsx
+++ b/src/pages/BveCvxInfluence.tsx
@@ -1,5 +1,5 @@
 import { observer } from 'mobx-react-lite';
-import React, { useContext } from 'react';
+import React, { useContext, useReducer } from 'react';
 import { StoreContext } from '../mobx/store-context';
 import { NETWORK_IDS, NETWORK_IDS_TO_NAMES } from '../config/constants';
 import routes from '../config/routes';
@@ -13,6 +13,9 @@ import { Holdings } from '../components-v2/vault-detail/holdings/Holdings';
 import { defaultVaultBalance } from '../components-v2/vault-detail/utils';
 import BveCvxInfoPanels from '../components-v2/BveCvxInfoPanels';
 import BveCvxSpecs from '../components-v2/BveCvxSpecs';
+import { VaultWithdraw } from '../components-v2/common/dialogs/VaultWithdraw';
+import { VaultDeposit } from '../components-v2/common/dialogs/VaultDeposit';
+import { MobileStickyActionButtons } from '../components-v2/vault-detail/actions/MobileStickyActionButtons';
 
 const useStyles = makeStyles((theme) => ({
 	root: {
@@ -49,12 +52,15 @@ const BveCvxInfluence = (): JSX.Element => {
 
 	const classes = useStyles();
 	const vault = vaults.getVault(vaultAddress);
+	const badgerVault = vault ? vaults.getVaultDefinition(vault) : undefined;
+	const [depositDisplayed, toggleDepositDisplayed] = useReducer((previous) => !previous, false);
+	const [withdrawDisplayed, toggleWithdrawDisplay] = useReducer((previous) => !previous, false);
 
 	if (network.id !== NETWORK_IDS.ETH) {
 		router.goTo(routes.home, {}, { chain: NETWORK_IDS_TO_NAMES[NETWORK_IDS.ETH] });
 	}
 
-	if (!vault) {
+	if (!vault || !badgerVault) {
 		return (
 			<Container className={classes.root}>
 				<div className={classes.notReadyContainer}>
@@ -67,24 +73,48 @@ const BveCvxInfluence = (): JSX.Element => {
 	const userData = user.accountDetails?.data[vault.vaultToken] ?? defaultVaultBalance(vault);
 
 	return (
-		<Container className={classes.root}>
-			<Header />
-			<TopContent vault={vault} />
-			{wallet.isConnected && (
-				<Grid container className={classes.holdingsContainer}>
-					<Holdings vault={vault} userData={userData} />
+		<>
+			<Container className={classes.root}>
+				<Header />
+				<TopContent vault={vault} />
+				{wallet.isConnected && (
+					<Grid container className={classes.holdingsContainer}>
+						<Holdings
+							vault={vault}
+							userData={userData}
+							onDepositClick={toggleDepositDisplayed}
+							onWithdrawClick={toggleWithdrawDisplay}
+						/>
+					</Grid>
+				)}
+				<Grid container spacing={1}>
+					<Grid item xs={12} md={4} lg={3}>
+						<BveCvxSpecs vault={vault} />
+					</Grid>
+					<Grid item xs={12} md={8} lg={9} className={classes.chartsContainer}>
+						<BveCvxInfoPanels vault={vault} />
+					</Grid>
 				</Grid>
-			)}
-			<Grid container spacing={1}>
-				<Grid item xs={12} md={4} lg={3}>
-					<BveCvxSpecs vault={vault} />
-				</Grid>
-				<Grid item xs={12} md={8} lg={9} className={classes.chartsContainer}>
-					<BveCvxInfoPanels vault={vault} />
-				</Grid>
-			</Grid>
-			<Footer vault={vault} />
-		</Container>
+				<Footer vault={vault} />
+			</Container>
+			<MobileStickyActionButtons
+				vault={vault}
+				onDepositClick={toggleDepositDisplayed}
+				onWithdrawClick={toggleWithdrawDisplay}
+			/>
+			<VaultDeposit
+				open={depositDisplayed}
+				vault={vault}
+				badgerVault={badgerVault}
+				onClose={toggleDepositDisplayed}
+			/>
+			<VaultWithdraw
+				open={withdrawDisplayed}
+				vault={vault}
+				badgerVault={badgerVault}
+				onClose={toggleWithdrawDisplay}
+			/>
+		</>
 	);
 };
 


### PR DESCRIPTION
all the dialogs-related components (dialog and buttons) were using data from the vault detail store context, I had to replace this with component-based states to be able to reuse the components.