### PR TITLE
chore: mark vaults as new

### DIFF
--- a/src/components-v2/VaultApyBreakdownItem/index.tsx
+++ b/src/components-v2/VaultApyBreakdownItem/index.tsx
@@ -37,7 +37,7 @@ const VaultApyBreakdownItem = ({ vault, source }: Props): JSX.Element => {
 
   // this is only possible because we're currently distributing BADGER. If in the future we distribute other tokens,
   // this will need to be updated to reflect that.
-  const isBoostBreakdown = source.name === 'Boosted Badger Rewards';
+  const isBoostBreakdown = source.name === 'Boosted Badger';
   const maxBoost = calculateUserBoost(MAX_BOOST_RANK.stakeRatioBoundary);
   const userBoost = user.accountDetails?.boost ?? 1;
   const sourceApr = source.boostable

--- a/src/components-v2/VaultApyBreakdownItem/index.tsx
+++ b/src/components-v2/VaultApyBreakdownItem/index.tsx
@@ -5,6 +5,7 @@ import { StoreContext } from 'mobx/stores/store-context';
 import { observer } from 'mobx-react-lite';
 import React, { useContext } from 'react';
 import { calculateUserBoost } from 'utils/boost-ranks';
+import { BoostedRewards } from 'utils/enums/boosted-rewards.enum';
 
 import routes from '../../config/routes';
 import { useVaultInformation } from '../../hooks/useVaultInformation';
@@ -37,7 +38,7 @@ const VaultApyBreakdownItem = ({ vault, source }: Props): JSX.Element => {
 
   // this is only possible because we're currently distributing BADGER. If in the future we distribute other tokens,
   // this will need to be updated to reflect that.
-  const isBoostBreakdown = source.name === 'Boosted Badger';
+  const isBoostBreakdown = source.name === BoostedRewards.BoostedBadger;
   const maxBoost = calculateUserBoost(MAX_BOOST_RANK.stakeRatioBoundary);
   const userBoost = user.accountDetails?.boost ?? 1;
   const sourceApr = source.boostable

--- a/src/components-v2/VaultApyInformation/index.tsx
+++ b/src/components-v2/VaultApyInformation/index.tsx
@@ -1,4 +1,4 @@
-import { VaultDTO } from '@badger-dao/sdk';
+import { VaultDTO, VaultState } from '@badger-dao/sdk';
 import {
   Button,
   Dialog,
@@ -45,8 +45,8 @@ const useStyles = makeStyles((theme) => ({
   button: {
     marginTop: 34,
   },
-  projectedAPY: {
-    paddingTop: 10,
+  historicAPY: {
+    paddingBottom: 10,
   },
 }));
 
@@ -64,7 +64,10 @@ const VaultApyInformation = ({ open, onClose, boost, vault, projectedBoost }: Pr
   const sources = vaults.vaultsFilters.showAPR ? vault.sources : vault.sourcesApy;
   //make sure boost sources are always the last one
   const sortedSources = sources.slice().sort((source) => (source.boostable ? 1 : -1));
-  const badgerRewardsSources = sortedSources.filter((source) => source.name.includes('Badger Rewards'));
+  const badgerRewardsSources = sortedSources.filter(
+    (source) => source.name === 'Badger' || source.name === 'Boosted Badger',
+  );
+  const isNewVault = vault.state === VaultState.Experimental || vault.state === VaultState.Guarded;
 
   const handleGoToVault = async (event: MouseEvent<HTMLElement>) => {
     event.stopPropagation();
@@ -107,31 +110,35 @@ const VaultApyInformation = ({ open, onClose, boost, vault, projectedBoost }: Pr
       </DialogTitle>
       <DialogContent className={classes.content}>
         <Grid container direction="column">
-          <Grid item container justifyContent="space-between">
-            <Grid item>
-              <Typography variant="subtitle1" display="inline" color="textSecondary">
-                Historic {vaults.vaultsFilters.showAPR ? 'APR' : 'APY'}
-              </Typography>
-            </Grid>
-            <Grid item>
-              <Typography variant="subtitle1" display="inline" color="textSecondary">
-                {`${numberWithCommas(boost.toFixed(2))}%`}
-              </Typography>
-            </Grid>
-          </Grid>
-          <Divider className={classes.divider} />
-          {sortedSources.map((source) => (
-            <React.Fragment key={source.name}>
-              <VaultApyBreakdownItem vault={vault} source={source} />
-              <Divider className={classes.divider} />
-            </React.Fragment>
-          ))}
-          {projectedBoost !== null && (
-            <>
-              <Grid className={classes.projectedAPY} item container justifyContent="space-between">
+          {!isNewVault && (
+            <div className={classes.historicAPY}>
+              <Grid item container justifyContent="space-between">
                 <Grid item>
                   <Typography variant="subtitle1" display="inline" color="textSecondary">
-                    Projected {vaults.vaultsFilters.showAPR ? 'APR' : 'APY'}
+                    Historic {vaults.vaultsFilters.showAPR ? 'APR' : 'APY'}
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  <Typography variant="subtitle1" display="inline" color="textSecondary">
+                    {`${numberWithCommas(boost.toFixed(2))}%`}
+                  </Typography>
+                </Grid>
+              </Grid>
+              <Divider className={classes.divider} />
+              {sortedSources.map((source) => (
+                <React.Fragment key={`historic-${source.name}`}>
+                  <VaultApyBreakdownItem vault={vault} source={source} />
+                  <Divider className={classes.divider} />
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+          {projectedBoost !== null && (
+            <>
+              <Grid item container justifyContent="space-between">
+                <Grid item>
+                  <Typography variant="subtitle1" display="inline" color="textSecondary">
+                    Current {vaults.vaultsFilters.showAPR ? 'APR' : 'APY'}
                   </Typography>
                 </Grid>
                 <Grid item>
@@ -159,7 +166,7 @@ const VaultApyInformation = ({ open, onClose, boost, vault, projectedBoost }: Pr
                 </div>
               ))}
               {badgerRewardsSources.map((source) => (
-                <React.Fragment key={source.name}>
+                <React.Fragment key={`current-${source.name}`}>
                   <VaultApyBreakdownItem vault={vault} source={source} />
                   <Divider className={classes.divider} />
                 </React.Fragment>

--- a/src/components-v2/VaultApyInformation/index.tsx
+++ b/src/components-v2/VaultApyInformation/index.tsx
@@ -14,6 +14,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import { StoreContext } from 'mobx/stores/store-context';
 import { observer } from 'mobx-react-lite';
 import React, { MouseEvent, useContext } from 'react';
+import { BoostedRewards } from 'utils/enums/boosted-rewards.enum';
 
 import routes from '../../config/routes';
 import { numberWithCommas } from '../../mobx/utils/helpers';
@@ -65,7 +66,7 @@ const VaultApyInformation = ({ open, onClose, boost, vault, projectedBoost }: Pr
   //make sure boost sources are always the last one
   const sortedSources = sources.slice().sort((source) => (source.boostable ? 1 : -1));
   const badgerRewardsSources = sortedSources.filter(
-    (source) => source.name === 'Badger' || source.name === 'Boosted Badger',
+    (source) => source.name === BoostedRewards.Badger || source.name === BoostedRewards.BoostedBadger,
   );
   const isNewVault = vault.state === VaultState.Experimental || vault.state === VaultState.Guarded;
 

--- a/src/components-v2/landing/VaultItemApr.tsx
+++ b/src/components-v2/landing/VaultItemApr.tsx
@@ -1,4 +1,4 @@
-import { VaultDTO } from '@badger-dao/sdk';
+import { VaultDTO, VaultState } from '@badger-dao/sdk';
 import { Box, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { numberWithCommas } from 'mobx/utils/helpers';
@@ -18,8 +18,9 @@ const useStyles = makeStyles({
     marginLeft: 5,
   },
   projectedApr: {
-    fontSize: 12,
-    marginTop: 5,
+    fontSize: 10,
+    marginTop: 3,
+    color: '#FFFFFF99',
   },
 });
 
@@ -51,6 +52,9 @@ const VaultItemApr = ({ vault, boost, projectedBoost }: Props): JSX.Element => {
     );
   }
 
+  const isNewVault = vault.state === VaultState.Experimental || vault.state === VaultState.Guarded;
+  const aprDisplay = isNewVault ? 'New Vault' : `${numberWithCommas(boost.toFixed(2))}%`;
+
   return (
     <Box
       display="flex"
@@ -60,8 +64,8 @@ const VaultItemApr = ({ vault, boost, projectedBoost }: Props): JSX.Element => {
       className={classes.root}
     >
       <Box display="flex">
-        <Typography variant="body1" color={'textPrimary'} display="inline">
-          {`${numberWithCommas(boost.toFixed(2))}%`}
+        <Typography variant={isNewVault ? 'subtitle2' : 'body1'} color={'textPrimary'} display="inline">
+          {aprDisplay}
         </Typography>
         <img src="/assets/icons/apy-info.svg" className={classes.apyInfo} alt="apy info icon" />
       </Box>

--- a/src/components-v2/landing/VaultLogo.tsx
+++ b/src/components-v2/landing/VaultLogo.tsx
@@ -20,7 +20,7 @@ const VaultLogo = ({ tokens, className, ...props }: Props): JSX.Element => {
   const classes = useStyles();
   return (
     <div className={clsx(classes.root, className && className)} {...props}>
-      {tokens.map((token, index, totalTokens) => (
+      {tokens.map((token, index) => (
         <ComposableTokenLogo token={token} logoPosition={index} key={`${token.symbol}_${index}`} />
       ))}
     </div>

--- a/src/tests/unit/token/token-balance.test.ts
+++ b/src/tests/unit/token/token-balance.test.ts
@@ -19,15 +19,6 @@ describe('token-balance', () => {
     return new TokenBalance(token, parseUnits(amount.toString(), token.decimals), price);
   };
 
-  const verifyScaledBalance = (mockBalance: TokenBalance, scaledBalance: TokenBalance, scalar: number): void => {
-    const expectedBalance = mockBalance.balance * scalar;
-    const expectedTokenBalance = mockBalance.tokenBalance.mul(scalar);
-    const expectedValue = mockBalance.value * scalar;
-    expect(scaledBalance.balance).toEqual(expectedBalance);
-    expect(scaledBalance.tokenBalance).toEqual(expectedTokenBalance);
-    expect(scaledBalance.value).toEqual(expectedValue);
-  };
-
   describe('fromBalance', () => {
     it('converts a visual balance string into a token balance representation', () => {
       const mockBalance = randomTokenBalance();

--- a/src/utils/componentHelpers.ts
+++ b/src/utils/componentHelpers.ts
@@ -6,6 +6,7 @@ import { MAX_BOOST_RANK } from '../config/system/boost-ranks';
 import { Chain } from '../mobx/model/network/chain';
 import UserStore from '../mobx/stores/UserStore';
 import { calculateUserBoost } from './boost-ranks';
+import { BoostedRewards } from './enums/boosted-rewards.enum';
 
 export const restrictToRange = (num: number, min: number, max: number): number => Math.min(Math.max(num, min), max);
 
@@ -82,7 +83,7 @@ export function getProjectedVaultBoost(vault: VaultDTO, boost: number): number {
   const maxBoost = calculateUserBoost(MAX_BOOST_RANK.stakeRatioBoundary);
   return vault.sources
     .map((source) => {
-      if (source.name === 'Badger' || source.name === 'Boosted Badger') {
+      if (source.name === BoostedRewards.Badger || source.name === BoostedRewards.BoostedBadger) {
         return source.minApr + (boost / maxBoost) * (source.maxApr - source.minApr);
       }
       return 0;

--- a/src/utils/componentHelpers.ts
+++ b/src/utils/componentHelpers.ts
@@ -82,7 +82,7 @@ export function getProjectedVaultBoost(vault: VaultDTO, boost: number): number {
   const maxBoost = calculateUserBoost(MAX_BOOST_RANK.stakeRatioBoundary);
   return vault.sources
     .map((source) => {
-      if (source.name.includes('Badger Rewards')) {
+      if (source.name === 'Badger' || source.name === 'Boosted Badger') {
         return source.minApr + (boost / maxBoost) * (source.maxApr - source.minApr);
       }
       return 0;

--- a/src/utils/enums/boosted-rewards.enum.ts
+++ b/src/utils/enums/boosted-rewards.enum.ts
@@ -1,0 +1,4 @@
+export enum BoostedRewards {
+  Badger = 'Badger',
+  BoostedBadger = 'Boosted Badger',
+}


### PR DESCRIPTION
# Summary

Fulfills request for 'new' vaults to show new, and projections. Slight tweaks to projection visualizations.