### PR TITLE
Close modal after successful deposit/withdraw transaction

### DIFF
--- a/src/components-v2/common/dialogs/VaultDeposit.tsx
+++ b/src/components-v2/common/dialogs/VaultDeposit.tsx
@@ -220,7 +220,7 @@ export const VaultDeposit = observer(({ open = false, vault, depositAdvisory, on
     });
     if (result === TransactionStatus.Success) {
       await user.reloadBalances();
-      vaultDetail.toggleDepositDialog();
+      onClose();
     }
   };
 

--- a/src/components-v2/common/dialogs/VaultWithdraw.tsx
+++ b/src/components-v2/common/dialogs/VaultWithdraw.tsx
@@ -190,7 +190,7 @@ export const VaultWithdraw = observer(({ open = false, vault, withdrawAdvisory, 
       });
       if (result === TransactionStatus.Success) {
         await user.reloadBalances();
-        vaultDetail.toggleWithdrawDialog();
+        onClose();
       }
     }
   };


### PR DESCRIPTION
While doing deposit and withdraw observed that the modal was not closing after a successful transaction.