### PR TITLE
refactor: utilize `grossYield` for app display

### DIFF
--- a/src/components-v2/InfluenceVault/InfluenceVaultPerfomanceTab.tsx
+++ b/src/components-v2/InfluenceVault/InfluenceVaultPerfomanceTab.tsx
@@ -63,8 +63,8 @@ const InfluenceVaultPerfomanceTab = ({ vault, config }: Props): JSX.Element => {
   const classes = useStyles();
   const sortedSources = vault.apy.sources
     .slice()
-    .sort((a, b) => (b.performance.baseYield > a.performance.baseYield ? 1 : -1));
-  const apy = vaults.vaultsFilters.showAPR ? vault.apr : vault.apy;
+    .sort((a, b) => (b.performance.grossYield > a.performance.grossYield ? 1 : -1));
+  const apy = vault.apy;
   const lockedBalance = lockedDeposits.getLockedDepositBalances(vault.underlyingToken);
   const { processingEmissions, emissionsSchedules, swapPercentage } = influenceVaultStore.getInfluenceVault(
     vault.vaultToken,
@@ -96,7 +96,7 @@ const InfluenceVaultPerfomanceTab = ({ vault, config }: Props): JSX.Element => {
                 APY
               </Typography>
               <Typography variant="body1" display="inline">
-                {numberWithCommas(String(apy.baseYield.toFixed(2)))}%
+                {numberWithCommas(String(apy.grossYield.toFixed(2)))}%
               </Typography>
             </Box>
             <Divider className={classes.divider} />

--- a/src/components-v2/VaultApyBreakdownItem/index.tsx
+++ b/src/components-v2/VaultApyBreakdownItem/index.tsx
@@ -65,7 +65,6 @@ const VaultApyBreakdownItem = ({ vault, source }: Props): JSX.Element => {
   const maxBoost = calculateUserBoost(MAX_BOOST_RANK.stakeRatioBoundary);
   const userBoost = user.accountDetails?.boost ?? 1;
 
-  // TODO: this is now duplicated p sure - probably should do a helper fn
   const sourceApr = source.boostable
     ? source.minApr + (source.maxApr - source.minApr) * (userBoost / maxBoost)
     : source.apr;

--- a/src/components-v2/VaultApyInformation/index.tsx
+++ b/src/components-v2/VaultApyInformation/index.tsx
@@ -130,13 +130,13 @@ export interface YieldValueSource extends ValueSource {
  * @returns value source derived from yield source
  */
 export function yieldToValueSource(source: YieldSource): ValueSource {
-  const { baseYield, minYield, maxYield } = source.performance;
+  const { grossYield, minGrossYield, maxGrossYield } = source.performance;
   return {
     name: source.name,
-    apr: baseYield,
+    apr: grossYield,
     boostable: source.boostable,
-    minApr: minYield,
-    maxApr: maxYield,
+    minApr: minGrossYield,
+    maxApr: maxGrossYield,
   };
 }
 
@@ -150,7 +150,7 @@ const VaultApyInformation = ({ open, onClose, boost, vault, projectedBoost }: Pr
   const classes = useStyles();
   const sortedSources = sources
     .slice()
-    .sort((a, b) => (isBadgerSource(b) ? -1 : b.performance.baseYield > a.performance.baseYield ? 1 : -1));
+    .sort((a, b) => (isBadgerSource(b) ? -1 : b.performance.grossYield > a.performance.grossYield ? 1 : -1));
   const badgerRewardsSources = sortedSources.filter(isBadgerSource);
   const harvestSources: YieldSourceDisplay[] = harvestPeriodSourcesApy;
   const additionalSources: YieldSourceDisplay[] = nonHarvestSourcesApy.map(yieldToValueSource);

--- a/src/hooks/useVaultInformation.ts
+++ b/src/hooks/useVaultInformation.ts
@@ -20,7 +20,7 @@ export function useVaultInformation(vault: VaultDTOV3): VaultInformation {
 
   const depositBalance = user.getBalance(vaultToken);
   const boostContribution = getBoostContribution(vault, user.accountDetails?.boost ?? 0);
-  const vaultBoost = apy.baseYield + boostContribution;
+  const vaultBoost = apy.grossYield + boostContribution;
 
   let projectedVaultBoost = null;
   if (vault.version === VaultVersion.v1_5) {

--- a/src/tests/__snapshots__/Landing.test.tsx.snap
+++ b/src/tests/__snapshots__/Landing.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Landing Renders correctly 1`] = `
                 </svg>
               </span>
               <span
-                class="MuiTouchRipple-root-641"
+                class="MuiTouchRipple-root-647"
               />
             </span>
             <span
@@ -81,7 +81,7 @@ exports[`Landing Renders correctly 1`] = `
                 </svg>
               </span>
               <span
-                class="MuiTouchRipple-root-641"
+                class="MuiTouchRipple-root-647"
               />
             </span>
             <span
@@ -122,7 +122,7 @@ exports[`Landing Renders correctly 1`] = `
                 </svg>
               </span>
               <span
-                class="MuiTouchRipple-root-641"
+                class="MuiTouchRipple-root-647"
               />
             </span>
             <span
@@ -154,7 +154,7 @@ exports[`Landing Renders correctly 1`] = `
                 APY
               </span>
               <span
-                class="MuiTouchRipple-root-641"
+                class="MuiTouchRipple-root-647"
               />
             </button>
             <button
@@ -169,7 +169,7 @@ exports[`Landing Renders correctly 1`] = `
                 APR
               </span>
               <span
-                class="MuiTouchRipple-root-641"
+                class="MuiTouchRipple-root-647"
               />
             </button>
           </div>
@@ -399,7 +399,7 @@ exports[`Landing Renders correctly 1`] = `
                     </svg>
                   </span>
                   <span
-                    class="MuiTouchRipple-root-641"
+                    class="MuiTouchRipple-root-647"
                   />
                 </button>
               </div>
@@ -434,7 +434,7 @@ exports[`Landing Renders correctly 1`] = `
               CLEAR ALL
             </span>
             <span
-              class="MuiTouchRipple-root-641"
+              class="MuiTouchRipple-root-647"
             />
           </button>
         </div>
@@ -473,7 +473,7 @@ exports[`Landing Renders correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-641"
+              class="MuiTouchRipple-root-647"
             />
           </button>
         </div>
@@ -501,7 +501,7 @@ exports[`Landing Renders correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-641"
+              class="MuiTouchRipple-root-647"
             />
           </button>
         </div>
@@ -529,7 +529,7 @@ exports[`Landing Renders correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-641"
+              class="MuiTouchRipple-root-647"
             />
           </button>
         </div>
@@ -557,7 +557,7 @@ exports[`Landing Renders correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-641"
+              class="MuiTouchRipple-root-647"
             />
           </button>
         </div>
@@ -574,7 +574,13 @@ exports[`Landing Renders correctly 1`] = `
         >
           <div
             class="makeStyles-root-405"
-          />
+          >
+            <img
+              alt="CVX logo"
+              class="makeStyles-position-406"
+              src="/assets/icons/cvx.svg"
+            />
+          </div>
         </div>
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-grid-xs-true-76 MuiGrid-grid-lg-5-123"
@@ -591,10 +597,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Convex
                 </span>
@@ -606,19 +612,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-447 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-448 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-448 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-449 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                28.04%
+                28.32%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -628,7 +634,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-478"
+            class="MuiBox-root-447 MuiBox-root-479"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -641,12 +647,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-482"
+            class="MuiBox-root-447 MuiBox-root-483"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $18,108,361
+              $13,738,345
             </p>
           </div>
         </div>
@@ -663,7 +669,13 @@ exports[`Landing Renders correctly 1`] = `
         >
           <div
             class="makeStyles-root-405"
-          />
+          >
+            <img
+              alt="cvxCRV logo"
+              class="makeStyles-position-484"
+              src="/assets/icons/cvxcrv.svg"
+            />
+          </div>
         </div>
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-grid-xs-true-76 MuiGrid-grid-lg-5-123"
@@ -680,10 +692,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Convex
                 </span>
@@ -693,10 +705,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 makeStyles-clickableTag-409 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Ecosystem Helper
                 </span>
@@ -706,10 +718,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   🚀 Boosted
                 </span>
@@ -721,19 +733,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-483 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-485 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-484 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-486 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                26.64%
+                18.48%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -743,7 +755,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-487"
+            class="MuiBox-root-447 MuiBox-root-489"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -756,12 +768,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-490"
+            class="MuiBox-root-447 MuiBox-root-492"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $5,841,390
+              $3,609,918
             </p>
           </div>
         </div>
@@ -778,7 +790,13 @@ exports[`Landing Renders correctly 1`] = `
         >
           <div
             class="makeStyles-root-405"
-          />
+          >
+            <img
+              alt="AURA logo"
+              class="makeStyles-position-493"
+              src="/assets/icons/aura.svg"
+            />
+          </div>
         </div>
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-grid-xs-true-76 MuiGrid-grid-lg-5-123"
@@ -795,10 +813,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Aura
                 </span>
@@ -810,19 +828,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-491 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-494 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-492 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-495 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                17.62%
+                80.91%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -832,7 +850,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-495"
+            class="MuiBox-root-447 MuiBox-root-498"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -845,141 +863,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-498"
+            class="MuiBox-root-447 MuiBox-root-501"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $2,525,602
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-395 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-2-66 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 makeStyles-iconBadgeContainer-399 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-        >
-          <div
-            class="makeStyles-root-405"
-          />
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-grid-xs-true-76 MuiGrid-grid-lg-5-123"
-        >
-          <h6
-            class="MuiTypography-root-182 makeStyles-vaultName-400 MuiTypography-subtitle1-193"
-          >
-            auraBAL
-          </h6>
-          <div
-            class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-2-66"
-          >
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  experimental
-                </span>
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  Aura
-                </span>
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  Ecosystem Helper
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
-        >
-          <div
-            class="MuiBox-root-446 MuiBox-root-499 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-500 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-501"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                109.00%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
-        >
-          <div
-            class="MuiBox-root-446 MuiBox-root-504"
-          >
-            <p
-              class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
-        >
-          <div
-            class="MuiBox-root-446 MuiBox-root-507"
-          >
-            <p
-              class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
-            >
-              $69,939
+              $2,753,168
             </p>
           </div>
         </div>
@@ -999,17 +888,135 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="auraBAL logo"
-              class="makeStyles-position-508"
+              class="makeStyles-position-502"
+              src="/assets/icons/aurabal.svg"
+            />
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-grid-xs-true-76 MuiGrid-grid-lg-5-123"
+        >
+          <h6
+            class="MuiTypography-root-182 makeStyles-vaultName-400 MuiTypography-subtitle1-193"
+          >
+            auraBAL
+          </h6>
+          <div
+            class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-2-66"
+          >
+            <div
+              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+            >
+              <div
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+              >
+                <span
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
+                >
+                  Aura
+                </span>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+            >
+              <div
+                class="MuiChip-root-411 makeStyles-tag-407 makeStyles-clickableTag-409 MuiChip-sizeSmall-412"
+              >
+                <span
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
+                >
+                  Ecosystem Helper
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
+        >
+          <div
+            class="MuiBox-root-447 MuiBox-root-503 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-504 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                14.91%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-505"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                65.00%
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
+        >
+          <div
+            class="MuiBox-root-447 MuiBox-root-508"
+          >
+            <p
+              class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
+        >
+          <div
+            class="MuiBox-root-447 MuiBox-root-511"
+          >
+            <p
+              class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
+            >
+              $836,428
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-395 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-2-66 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 makeStyles-iconBadgeContainer-399 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+        >
+          <div
+            class="makeStyles-root-405"
+          >
+            <img
+              alt="auraBAL logo"
+              class="makeStyles-position-512"
               src="/assets/icons/aurabal.svg"
             />
             <img
               alt="graviAURA logo"
-              class="makeStyles-position-509"
+              class="makeStyles-position-513"
               src="/assets/icons/graviaura.svg"
             />
             <img
               alt="WETH logo"
-              class="makeStyles-position-510"
+              class="makeStyles-position-514"
               src="/assets/icons/weth.svg"
             />
           </div>
@@ -1029,23 +1036,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  experimental
-                </span>
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Aura
                 </span>
@@ -1057,34 +1051,30 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-511 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-515 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-512 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-516 makeStyles-aprDisplay-444"
             >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
+                56.93%
+              </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
             <div
-              class="MuiBox-root-446 MuiBox-root-513"
+              class="MuiBox-root-447 MuiBox-root-517"
             >
               <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
               >
                 Current: 
-                161.03%
+                95.64%
               </p>
             </div>
           </div>
@@ -1093,7 +1083,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-516"
+            class="MuiBox-root-447 MuiBox-root-520"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1106,12 +1096,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-519"
+            class="MuiBox-root-447 MuiBox-root-523"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $73,432
+              $106,996
             </p>
           </div>
         </div>
@@ -1131,12 +1121,12 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="WBTC logo"
-              class="makeStyles-position-520"
+              class="makeStyles-position-524"
               src="/assets/icons/wbtc.svg"
             />
             <img
               alt="BADGER logo"
-              class="makeStyles-position-521"
+              class="makeStyles-position-525"
               src="/assets/icons/badger.svg"
             />
           </div>
@@ -1156,23 +1146,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  experimental
-                </span>
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Aura
                 </span>
@@ -1184,34 +1161,30 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-522 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-526 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-523 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-527 makeStyles-aprDisplay-444"
             >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
+                62.26%
+              </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
             <div
-              class="MuiBox-root-446 MuiBox-root-524"
+              class="MuiBox-root-447 MuiBox-root-528"
             >
               <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
               >
                 Current: 
-                34.29%
+                166.58%
               </p>
             </div>
           </div>
@@ -1220,7 +1193,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-527"
+            class="MuiBox-root-447 MuiBox-root-531"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1233,12 +1206,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-530"
+            class="MuiBox-root-447 MuiBox-root-534"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $544,871
+              $2,739,793
             </p>
           </div>
         </div>
@@ -1258,17 +1231,17 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="WBTC logo"
-              class="makeStyles-position-531"
+              class="makeStyles-position-535"
               src="/assets/icons/wbtc.svg"
             />
             <img
               alt="DIGG logo"
-              class="makeStyles-position-532"
+              class="makeStyles-position-536"
               src="/assets/icons/digg.svg"
             />
             <img
               alt="graviAURA logo"
-              class="makeStyles-position-533"
+              class="makeStyles-position-537"
               src="/assets/icons/graviaura.svg"
             />
           </div>
@@ -1288,23 +1261,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  experimental
-                </span>
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Aura
                 </span>
@@ -1316,34 +1276,30 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-534 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-538 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-535 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-539 makeStyles-aprDisplay-444"
             >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
+                43.99%
+              </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
             <div
-              class="MuiBox-root-446 MuiBox-root-536"
+              class="MuiBox-root-447 MuiBox-root-540"
             >
               <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
               >
                 Current: 
-                297.48%
+                5.08%
               </p>
             </div>
           </div>
@@ -1352,7 +1308,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-539"
+            class="MuiBox-root-447 MuiBox-root-543"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1365,12 +1321,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-542"
+            class="MuiBox-root-447 MuiBox-root-546"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $798,703
+              $744,657
             </p>
           </div>
         </div>
@@ -1390,12 +1346,12 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="CVX logo"
-              class="makeStyles-position-543"
+              class="makeStyles-position-547"
               src="/assets/icons/cvx.svg"
             />
             <img
               alt="bveCVX logo"
-              class="makeStyles-position-544"
+              class="makeStyles-position-548"
               src="/assets/icons/bvecvx.svg"
             />
           </div>
@@ -1415,10 +1371,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Curve
                 </span>
@@ -1430,19 +1386,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-545 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-549 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-546 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-550 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                20.46%
+                36.69%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -1452,7 +1408,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-549"
+            class="MuiBox-root-447 MuiBox-root-553"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1465,12 +1421,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-552"
+            class="MuiBox-root-447 MuiBox-root-556"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $1,232,538
+              $832,345
             </p>
           </div>
         </div>
@@ -1490,12 +1446,12 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="wibBTC logo"
-              class="makeStyles-position-553"
+              class="makeStyles-position-557"
               src="/assets/icons/wibbtc.svg"
             />
             <img
               alt="crvRenWSBTC logo"
-              class="makeStyles-position-554"
+              class="makeStyles-position-558"
               src="/assets/icons/crvrenwsbtc.svg"
             />
           </div>
@@ -1515,10 +1471,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Convex
                 </span>
@@ -1528,10 +1484,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   🚀 Boosted
                 </span>
@@ -1543,19 +1499,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-555 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-559 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-556 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-560 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                16.78%
+                20.29%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -1565,7 +1521,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-559"
+            class="MuiBox-root-447 MuiBox-root-563"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1578,12 +1534,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-562"
+            class="MuiBox-root-447 MuiBox-root-566"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $27,471,043
+              $19,814,734
             </p>
           </div>
         </div>
@@ -1603,12 +1559,12 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="BADGER logo"
-              class="makeStyles-position-563"
+              class="makeStyles-position-567"
               src="/assets/icons/badger.svg"
             />
             <img
               alt="WBTC logo"
-              class="makeStyles-position-564"
+              class="makeStyles-position-568"
               src="/assets/icons/wbtc.svg"
             />
           </div>
@@ -1628,10 +1584,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Convex
                 </span>
@@ -1643,19 +1599,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-565 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-569 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-566 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-570 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                19.15%
+                4.77%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -1665,7 +1621,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-569"
+            class="MuiBox-root-447 MuiBox-root-573"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1678,12 +1634,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-572"
+            class="MuiBox-root-447 MuiBox-root-576"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $3,998,480
+              $2,708,612
             </p>
           </div>
         </div>
@@ -1703,12 +1659,12 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="WBTC logo"
-              class="makeStyles-position-573"
+              class="makeStyles-position-577"
               src="/assets/icons/wbtc.svg"
             />
             <img
               alt="BADGER logo"
-              class="makeStyles-position-574"
+              class="makeStyles-position-578"
               src="/assets/icons/badger.svg"
             />
           </div>
@@ -1728,10 +1684,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Sushiswap
                 </span>
@@ -1743,19 +1699,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-575 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-579 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-576 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-580 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                21.17%
+                7.03%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -1765,7 +1721,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-579"
+            class="MuiBox-root-447 MuiBox-root-583"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1778,12 +1734,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-582"
+            class="MuiBox-root-447 MuiBox-root-586"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $1,530,831
+              $1,224,135
             </p>
           </div>
         </div>
@@ -1803,7 +1759,7 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="WBTC logo"
-              class="makeStyles-position-583"
+              class="makeStyles-position-587"
               src="/assets/icons/wbtc.svg"
             />
           </div>
@@ -1823,10 +1779,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Yearn
                 </span>
@@ -1837,17 +1793,30 @@ exports[`Landing Renders correctly 1`] = `
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
-          <p
-            class="MuiTypography-root-182 makeStyles-apr-441 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207"
+          <div
+            class="MuiBox-root-447 MuiBox-root-588 makeStyles-root-441"
           >
-            --%
-          </p>
+            <div
+              class="MuiBox-root-447 MuiBox-root-589 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                0.00%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
         </div>
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-586"
+            class="MuiBox-root-447 MuiBox-root-592"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1860,12 +1829,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-589"
+            class="MuiBox-root-447 MuiBox-root-595"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $2,942,012
+              $1,565,378
             </p>
           </div>
         </div>
@@ -1885,12 +1854,12 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="WBTC logo"
-              class="makeStyles-position-590"
+              class="makeStyles-position-596"
               src="/assets/icons/wbtc.svg"
             />
             <img
               alt="WETH logo"
-              class="makeStyles-position-591"
+              class="makeStyles-position-597"
               src="/assets/icons/weth.svg"
             />
           </div>
@@ -1910,10 +1879,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Sushiswap
                 </span>
@@ -1925,19 +1894,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-592 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-598 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-593 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-599 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                2.60%
+                2.23%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -1947,7 +1916,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-596"
+            class="MuiBox-root-447 MuiBox-root-602"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -1960,12 +1929,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-599"
+            class="MuiBox-root-447 MuiBox-root-605"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $9,057,468
+              $7,835,152
             </p>
           </div>
         </div>
@@ -1985,17 +1954,17 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="bb-a-USDT logo"
-              class="makeStyles-position-600"
+              class="makeStyles-position-606"
               src="/assets/icons/bb-a-usdt.svg"
             />
             <img
               alt="bb-a-DAI logo"
-              class="makeStyles-position-601"
+              class="makeStyles-position-607"
               src="/assets/icons/bb-a-dai.svg"
             />
             <img
               alt="bb-a-USDC logo"
-              class="makeStyles-position-602"
+              class="makeStyles-position-608"
               src="/assets/icons/bb-a-usdc.svg"
             />
           </div>
@@ -2015,38 +1984,12 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  experimental
-                </span>
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Aura
-                </span>
-              </div>
-            </div>
-            <div
-              class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-            >
-              <div
-                class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-              >
-                <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
-                >
-                  Ecosystem Helper
                 </span>
               </div>
             </div>
@@ -2056,34 +1999,30 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-603 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-609 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-604 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-610 makeStyles-aprDisplay-444"
             >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
+                1.75%
+              </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
             <div
-              class="MuiBox-root-446 MuiBox-root-605"
+              class="MuiBox-root-447 MuiBox-root-611"
             >
               <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
               >
                 Current: 
-                7.61%
+                6.89%
               </p>
             </div>
           </div>
@@ -2092,7 +2031,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-608"
+            class="MuiBox-root-447 MuiBox-root-614"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -2105,12 +2044,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-611"
+            class="MuiBox-root-447 MuiBox-root-617"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $101,577
+              $204,737
             </p>
           </div>
         </div>
@@ -2130,12 +2069,12 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="renBTC logo"
-              class="makeStyles-position-612"
+              class="makeStyles-position-618"
               src="/assets/icons/renbtc.svg"
             />
             <img
               alt="WBTC logo"
-              class="makeStyles-position-613"
+              class="makeStyles-position-619"
               src="/assets/icons/wbtc.svg"
             />
           </div>
@@ -2155,10 +2094,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Convex
                 </span>
@@ -2170,19 +2109,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-614 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-620 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-615 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-621 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                2.01%
+                0.92%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -2192,7 +2131,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-618"
+            class="MuiBox-root-447 MuiBox-root-624"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -2205,12 +2144,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-621"
+            class="MuiBox-root-447 MuiBox-root-627"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $18,683,481
+              $13,628,486
             </p>
           </div>
         </div>
@@ -2230,17 +2169,17 @@ exports[`Landing Renders correctly 1`] = `
           >
             <img
               alt="USDT logo"
-              class="makeStyles-position-622"
+              class="makeStyles-position-628"
               src="/assets/icons/usdt.svg"
             />
             <img
               alt="WBTC logo"
-              class="makeStyles-position-623"
+              class="makeStyles-position-629"
               src="/assets/icons/wbtc.svg"
             />
             <img
               alt="WETH logo"
-              class="makeStyles-position-624"
+              class="makeStyles-position-630"
               src="/assets/icons/weth.svg"
             />
           </div>
@@ -2260,10 +2199,10 @@ exports[`Landing Renders correctly 1`] = `
               class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
             >
               <div
-                class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+                class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
               >
                 <span
-                  class="MuiChip-label-432 MuiChip-labelSmall-433"
+                  class="MuiChip-label-433 MuiChip-labelSmall-434"
                 >
                   Convex
                 </span>
@@ -2275,19 +2214,19 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-align-items-xs-center-51 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-625 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-631 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-626 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-632 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                14.58%
+                2.14%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -2297,7 +2236,7 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-629"
+            class="MuiBox-root-447 MuiBox-root-635"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
@@ -2310,12 +2249,12 @@ exports[`Landing Renders correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <div
-            class="MuiBox-root-446 MuiBox-root-632"
+            class="MuiBox-root-447 MuiBox-root-638"
           >
             <p
               class="MuiTypography-root-182 makeStyles-itemText-397 MuiTypography-body1-184"
             >
-              $893,363
+              $817,047
             </p>
           </div>
         </div>
@@ -2367,7 +2306,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
                 </svg>
               </span>
               <span
-                class="MuiTouchRipple-root-643"
+                class="MuiTouchRipple-root-649"
               />
             </span>
             <span
@@ -2385,12 +2324,12 @@ exports[`Landing Renders mobile version correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <button
-            class="MuiButtonBase-root-170 MuiButton-root-239 MuiButton-text-241 makeStyles-button-641"
+            class="MuiButtonBase-root-170 MuiButton-root-239 MuiButton-text-241 makeStyles-button-647"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiButton-label-240 makeStyles-buttonLabel-642"
+              class="MuiButton-label-240 makeStyles-buttonLabel-648"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body2-183 MuiTypography-displayInline-210"
@@ -2409,7 +2348,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
               </svg>
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -2448,7 +2387,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -2476,7 +2415,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -2504,7 +2443,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -2532,29 +2471,35 @@ exports[`Landing Renders mobile version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="makeStyles-root-405"
-        />
+        >
+          <img
+            alt="CVX logo"
+            class="makeStyles-position-662"
+            src="/assets/icons/cvx.svg"
+          />
+        </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
           bveCVX
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -2565,19 +2510,19 @@ exports[`Landing Renders mobile version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-656 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-663 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-657 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-664 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                28.04%
+                28.32%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -2592,7 +2537,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-660"
+            class="MuiBox-root-447 MuiBox-root-667"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -2612,10 +2557,10 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>
@@ -2625,22 +2570,28 @@ exports[`Landing Renders mobile version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="makeStyles-root-405"
-        />
+        >
+          <img
+            alt="cvxCRV logo"
+            class="makeStyles-position-668"
+            src="/assets/icons/cvxcrv.svg"
+          />
+        </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
           cvxCRV
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -2651,19 +2602,19 @@ exports[`Landing Renders mobile version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-661 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-669 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-662 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-670 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                26.64%
+                18.48%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -2678,7 +2629,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-665"
+            class="MuiBox-root-447 MuiBox-root-673"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -2698,10 +2649,10 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>
@@ -2711,10 +2662,10 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 makeStyles-clickableTag-409 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Ecosystem Helper
               </span>
@@ -2724,10 +2675,10 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 🚀 Boosted
               </span>
@@ -2737,22 +2688,28 @@ exports[`Landing Renders mobile version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="makeStyles-root-405"
-        />
+        >
+          <img
+            alt="AURA logo"
+            class="makeStyles-position-674"
+            src="/assets/icons/aura.svg"
+          />
+        </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
           graviAURA
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -2763,19 +2720,19 @@ exports[`Landing Renders mobile version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-666 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-675 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-667 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-676 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                17.62%
+                80.91%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -2790,7 +2747,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-670"
+            class="MuiBox-root-447 MuiBox-root-679"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -2810,10 +2767,10 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Aura
               </span>
@@ -2823,133 +2780,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        />
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          auraBAL
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-671 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-672 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-673"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                109.00%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-676"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Ecosystem Helper
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
@@ -2959,28 +2790,18 @@ exports[`Landing Renders mobile version correctly 1`] = `
         >
           <img
             alt="auraBAL logo"
-            class="makeStyles-position-677"
+            class="makeStyles-position-680"
             src="/assets/icons/aurabal.svg"
           />
-          <img
-            alt="graviAURA logo"
-            class="makeStyles-position-678"
-            src="/assets/icons/graviaura.svg"
-          />
-          <img
-            alt="WETH logo"
-            class="makeStyles-position-679"
-            src="/assets/icons/weth.svg"
-          />
         </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
-          graviAURA/auraBAL/WETH
+          auraBAL
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -2991,34 +2812,30 @@ exports[`Landing Renders mobile version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-680 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-681 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-681 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-682 makeStyles-aprDisplay-444"
             >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
+                14.91%
+              </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
             <div
-              class="MuiBox-root-446 MuiBox-root-682"
+              class="MuiBox-root-447 MuiBox-root-683"
             >
               <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
               >
                 Current: 
-                161.03%
+                65.00%
               </p>
             </div>
           </div>
@@ -3032,7 +2849,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-685"
+            class="MuiBox-root-447 MuiBox-root-686"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -3052,982 +2869,10 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-686"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="BADGER logo"
-            class="makeStyles-position-687"
-            src="/assets/icons/badger.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          BADGER/WBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-688 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-689 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-690"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                34.29%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-693"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-694"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="DIGG logo"
-            class="makeStyles-position-695"
-            src="/assets/icons/digg.svg"
-          />
-          <img
-            alt="graviAURA logo"
-            class="makeStyles-position-696"
-            src="/assets/icons/graviaura.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          graviAURA/DIGG/WBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-697 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-698 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-699"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                297.48%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-702"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="CVX logo"
-            class="makeStyles-position-703"
-            src="/assets/icons/cvx.svg"
-          />
-          <img
-            alt="bveCVX logo"
-            class="makeStyles-position-704"
-            src="/assets/icons/bvecvx.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          CVX/bveCVX
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-705 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-706 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                20.46%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-709"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Curve
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="wibBTC logo"
-            class="makeStyles-position-710"
-            src="/assets/icons/wibbtc.svg"
-          />
-          <img
-            alt="crvRenWSBTC logo"
-            class="makeStyles-position-711"
-            src="/assets/icons/crvrenwsbtc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          ibBTC/crvsBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-712 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-713 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                16.78%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-716"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Convex
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                🚀 Boosted
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="BADGER logo"
-            class="makeStyles-position-717"
-            src="/assets/icons/badger.svg"
-          />
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-718"
-            src="/assets/icons/wbtc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          BADGER/WBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-719 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-720 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                19.15%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-723"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Convex
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-724"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="BADGER logo"
-            class="makeStyles-position-725"
-            src="/assets/icons/badger.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          wBTC/Badger
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-726 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-727 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                21.17%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-730"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Sushiswap
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-731"
-            src="/assets/icons/wbtc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          wBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <p
-            class="MuiTypography-root-182 makeStyles-apr-441 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207"
-          >
-            --%
-          </p>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-734"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Yearn
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-735"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="WETH logo"
-            class="makeStyles-position-736"
-            src="/assets/icons/weth.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          wBTC/wETH
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-737 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-738 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                2.60%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-741"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Sushiswap
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="bb-a-USDT logo"
-            class="makeStyles-position-742"
-            src="/assets/icons/bb-a-usdt.svg"
-          />
-          <img
-            alt="bb-a-DAI logo"
-            class="makeStyles-position-743"
-            src="/assets/icons/bb-a-dai.svg"
-          />
-          <img
-            alt="bb-a-USDC logo"
-            class="makeStyles-position-744"
-            src="/assets/icons/bb-a-usdc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          bb-a-USD
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-745 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-746 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-747"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                7.61%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-750"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Aura
               </span>
@@ -4037,10 +2882,10 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 makeStyles-clickableTag-409 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Ecosystem Helper
               </span>
@@ -4050,7 +2895,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
@@ -4059,24 +2904,29 @@ exports[`Landing Renders mobile version correctly 1`] = `
           class="makeStyles-root-405"
         >
           <img
-            alt="renBTC logo"
-            class="makeStyles-position-751"
-            src="/assets/icons/renbtc.svg"
+            alt="auraBAL logo"
+            class="makeStyles-position-687"
+            src="/assets/icons/aurabal.svg"
           />
           <img
-            alt="WBTC logo"
-            class="makeStyles-position-752"
-            src="/assets/icons/wbtc.svg"
+            alt="graviAURA logo"
+            class="makeStyles-position-688"
+            src="/assets/icons/graviaura.svg"
+          />
+          <img
+            alt="WETH logo"
+            class="makeStyles-position-689"
+            src="/assets/icons/weth.svg"
           />
         </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
-          renBTC/wBTC
+          graviAURA/auraBAL/WETH
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -4087,21 +2937,31 @@ exports[`Landing Renders mobile version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-753 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-690 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-754 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-691 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                2.01%
+                56.93%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-692"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                95.64%
+              </p>
             </div>
           </div>
         </div>
@@ -4114,7 +2974,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-757"
+            class="MuiBox-root-447 MuiBox-root-695"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -4134,10 +2994,533 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-696"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="BADGER logo"
+            class="makeStyles-position-697"
+            src="/assets/icons/badger.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          BADGER/WBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-698 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-699 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                62.26%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-700"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                166.58%
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-703"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-704"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="DIGG logo"
+            class="makeStyles-position-705"
+            src="/assets/icons/digg.svg"
+          />
+          <img
+            alt="graviAURA logo"
+            class="makeStyles-position-706"
+            src="/assets/icons/graviaura.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          graviAURA/DIGG/WBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-707 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-708 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                43.99%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-709"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                5.08%
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-712"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="CVX logo"
+            class="makeStyles-position-713"
+            src="/assets/icons/cvx.svg"
+          />
+          <img
+            alt="bveCVX logo"
+            class="makeStyles-position-714"
+            src="/assets/icons/bvecvx.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          CVX/bveCVX
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-715 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-716 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                36.69%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-719"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Curve
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="wibBTC logo"
+            class="makeStyles-position-720"
+            src="/assets/icons/wibbtc.svg"
+          />
+          <img
+            alt="crvRenWSBTC logo"
+            class="makeStyles-position-721"
+            src="/assets/icons/crvrenwsbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          ibBTC/crvsBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-722 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-723 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                20.29%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-726"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Convex
+              </span>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                🚀 Boosted
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="BADGER logo"
+            class="makeStyles-position-727"
+            src="/assets/icons/badger.svg"
+          />
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-728"
+            src="/assets/icons/wbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          BADGER/WBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-729 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-730 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                4.77%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-733"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>
@@ -4147,7 +3530,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
@@ -4156,29 +3539,24 @@ exports[`Landing Renders mobile version correctly 1`] = `
           class="makeStyles-root-405"
         >
           <img
-            alt="USDT logo"
-            class="makeStyles-position-758"
-            src="/assets/icons/usdt.svg"
-          />
-          <img
             alt="WBTC logo"
-            class="makeStyles-position-759"
+            class="makeStyles-position-734"
             src="/assets/icons/wbtc.svg"
           />
           <img
-            alt="WETH logo"
-            class="makeStyles-position-760"
-            src="/assets/icons/weth.svg"
+            alt="BADGER logo"
+            class="makeStyles-position-735"
+            src="/assets/icons/badger.svg"
           />
         </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
-          Tricrypto2
+          wBTC/Badger
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -4189,19 +3567,19 @@ exports[`Landing Renders mobile version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-761 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-736 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-762 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-737 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                14.58%
+                7.03%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -4216,7 +3594,7 @@ exports[`Landing Renders mobile version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-765"
+            class="MuiBox-root-447 MuiBox-root-740"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -4236,10 +3614,510 @@ exports[`Landing Renders mobile version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Sushiswap
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-741"
+            src="/assets/icons/wbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          wBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-742 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-743 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                0.00%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-746"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Yearn
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-747"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="WETH logo"
+            class="makeStyles-position-748"
+            src="/assets/icons/weth.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          wBTC/wETH
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-749 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-750 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                2.23%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-753"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Sushiswap
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="bb-a-USDT logo"
+            class="makeStyles-position-754"
+            src="/assets/icons/bb-a-usdt.svg"
+          />
+          <img
+            alt="bb-a-DAI logo"
+            class="makeStyles-position-755"
+            src="/assets/icons/bb-a-dai.svg"
+          />
+          <img
+            alt="bb-a-USDC logo"
+            class="makeStyles-position-756"
+            src="/assets/icons/bb-a-usdc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          bb-a-USD
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-757 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-758 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                1.75%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-759"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                6.89%
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-762"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="renBTC logo"
+            class="makeStyles-position-763"
+            src="/assets/icons/renbtc.svg"
+          />
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-764"
+            src="/assets/icons/wbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          renBTC/wBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-765 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-766 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                0.92%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-769"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Convex
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="USDT logo"
+            class="makeStyles-position-770"
+            src="/assets/icons/usdt.svg"
+          />
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-771"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="WETH logo"
+            class="makeStyles-position-772"
+            src="/assets/icons/weth.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          Tricrypto2
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-773 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-774 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                2.14%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-777"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>
@@ -4294,7 +4172,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
                 </svg>
               </span>
               <span
-                class="MuiTouchRipple-root-643"
+                class="MuiTouchRipple-root-649"
               />
             </span>
             <span
@@ -4312,12 +4190,12 @@ exports[`Landing Renders tablet version correctly 1`] = `
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-justify-content-xs-flex-end-61 MuiGrid-grid-xs-true-76"
         >
           <button
-            class="MuiButtonBase-root-170 MuiButton-root-239 MuiButton-text-241 makeStyles-button-641"
+            class="MuiButtonBase-root-170 MuiButton-root-239 MuiButton-text-241 makeStyles-button-647"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiButton-label-240 makeStyles-buttonLabel-642"
+              class="MuiButton-label-240 makeStyles-buttonLabel-648"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body2-183 MuiTypography-displayInline-210"
@@ -4336,7 +4214,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
               </svg>
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -4375,7 +4253,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -4403,7 +4281,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -4431,7 +4309,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
@@ -4459,29 +4337,35 @@ exports[`Landing Renders tablet version correctly 1`] = `
               />
             </span>
             <span
-              class="MuiTouchRipple-root-643"
+              class="MuiTouchRipple-root-649"
             />
           </button>
         </div>
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="makeStyles-root-405"
-        />
+        >
+          <img
+            alt="CVX logo"
+            class="makeStyles-position-662"
+            src="/assets/icons/cvx.svg"
+          />
+        </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
           bveCVX
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -4492,19 +4376,19 @@ exports[`Landing Renders tablet version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-656 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-663 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-657 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-664 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                28.04%
+                28.32%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -4519,7 +4403,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-660"
+            class="MuiBox-root-447 MuiBox-root-667"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -4539,10 +4423,10 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>
@@ -4552,22 +4436,28 @@ exports[`Landing Renders tablet version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="makeStyles-root-405"
-        />
+        >
+          <img
+            alt="cvxCRV logo"
+            class="makeStyles-position-668"
+            src="/assets/icons/cvxcrv.svg"
+          />
+        </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
           cvxCRV
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -4578,19 +4468,19 @@ exports[`Landing Renders tablet version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-661 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-669 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-662 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-670 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                26.64%
+                18.48%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -4605,7 +4495,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-665"
+            class="MuiBox-root-447 MuiBox-root-673"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -4625,10 +4515,10 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>
@@ -4638,10 +4528,10 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 makeStyles-clickableTag-409 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Ecosystem Helper
               </span>
@@ -4651,10 +4541,10 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 🚀 Boosted
               </span>
@@ -4664,22 +4554,28 @@ exports[`Landing Renders tablet version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="makeStyles-root-405"
-        />
+        >
+          <img
+            alt="AURA logo"
+            class="makeStyles-position-674"
+            src="/assets/icons/aura.svg"
+          />
+        </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
           graviAURA
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -4690,19 +4586,19 @@ exports[`Landing Renders tablet version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-666 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-675 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-667 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-676 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                17.62%
+                80.91%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -4717,7 +4613,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-670"
+            class="MuiBox-root-447 MuiBox-root-679"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -4737,10 +4633,10 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Aura
               </span>
@@ -4750,133 +4646,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        />
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          auraBAL
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-671 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-672 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-673"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                109.00%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-676"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Ecosystem Helper
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
@@ -4886,28 +4656,18 @@ exports[`Landing Renders tablet version correctly 1`] = `
         >
           <img
             alt="auraBAL logo"
-            class="makeStyles-position-677"
+            class="makeStyles-position-680"
             src="/assets/icons/aurabal.svg"
           />
-          <img
-            alt="graviAURA logo"
-            class="makeStyles-position-678"
-            src="/assets/icons/graviaura.svg"
-          />
-          <img
-            alt="WETH logo"
-            class="makeStyles-position-679"
-            src="/assets/icons/weth.svg"
-          />
         </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
-          graviAURA/auraBAL/WETH
+          auraBAL
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -4918,34 +4678,30 @@ exports[`Landing Renders tablet version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-680 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-681 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-681 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-682 makeStyles-aprDisplay-444"
             >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
+                14.91%
+              </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
             <div
-              class="MuiBox-root-446 MuiBox-root-682"
+              class="MuiBox-root-447 MuiBox-root-683"
             >
               <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
               >
                 Current: 
-                161.03%
+                65.00%
               </p>
             </div>
           </div>
@@ -4959,7 +4715,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-685"
+            class="MuiBox-root-447 MuiBox-root-686"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -4979,982 +4735,10 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-686"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="BADGER logo"
-            class="makeStyles-position-687"
-            src="/assets/icons/badger.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          BADGER/WBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-688 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-689 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-690"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                34.29%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-693"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-694"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="DIGG logo"
-            class="makeStyles-position-695"
-            src="/assets/icons/digg.svg"
-          />
-          <img
-            alt="graviAURA logo"
-            class="makeStyles-position-696"
-            src="/assets/icons/graviaura.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          graviAURA/DIGG/WBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-697 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-698 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-699"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                297.48%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-702"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Aura
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="CVX logo"
-            class="makeStyles-position-703"
-            src="/assets/icons/cvx.svg"
-          />
-          <img
-            alt="bveCVX logo"
-            class="makeStyles-position-704"
-            src="/assets/icons/bvecvx.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          CVX/bveCVX
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-705 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-706 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                20.46%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-709"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Curve
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="wibBTC logo"
-            class="makeStyles-position-710"
-            src="/assets/icons/wibbtc.svg"
-          />
-          <img
-            alt="crvRenWSBTC logo"
-            class="makeStyles-position-711"
-            src="/assets/icons/crvrenwsbtc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          ibBTC/crvsBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-712 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-713 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                16.78%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-716"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Convex
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                🚀 Boosted
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="BADGER logo"
-            class="makeStyles-position-717"
-            src="/assets/icons/badger.svg"
-          />
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-718"
-            src="/assets/icons/wbtc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          BADGER/WBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-719 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-720 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                19.15%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-723"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Convex
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-724"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="BADGER logo"
-            class="makeStyles-position-725"
-            src="/assets/icons/badger.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          wBTC/Badger
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-726 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-727 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                21.17%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-730"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Sushiswap
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-731"
-            src="/assets/icons/wbtc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          wBTC
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <p
-            class="MuiTypography-root-182 makeStyles-apr-441 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207"
-          >
-            --%
-          </p>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-734"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Yearn
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="WBTC logo"
-            class="makeStyles-position-735"
-            src="/assets/icons/wbtc.svg"
-          />
-          <img
-            alt="WETH logo"
-            class="makeStyles-position-736"
-            src="/assets/icons/weth.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          wBTC/wETH
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-737 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-738 makeStyles-aprDisplay-443"
-            >
-              <p
-                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                2.60%
-              </p>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-741"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                Sushiswap
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
-    >
-      <div
-        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="makeStyles-root-405"
-        >
-          <img
-            alt="bb-a-USDT logo"
-            class="makeStyles-position-742"
-            src="/assets/icons/bb-a-usdt.svg"
-          />
-          <img
-            alt="bb-a-DAI logo"
-            class="makeStyles-position-743"
-            src="/assets/icons/bb-a-dai.svg"
-          />
-          <img
-            alt="bb-a-USDC logo"
-            class="makeStyles-position-744"
-            src="/assets/icons/bb-a-usdc.svg"
-          />
-        </div>
-        <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
-        >
-          bb-a-USD
-        </h6>
-      </div>
-      <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            APY
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-745 makeStyles-root-440"
-          >
-            <div
-              class="MuiBox-root-446 MuiBox-root-746 makeStyles-aprDisplay-443"
-            >
-              <h6
-                class="MuiTypography-root-182 MuiTypography-subtitle1-193 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
-              >
-                <img
-                  alt="New Vault"
-                  src="assets/icons/new-vault.svg"
-                />
-                 New Vault
-              </h6>
-              <img
-                alt="apy info icon"
-                class="makeStyles-apyInfo-442"
-                src="/assets/icons/apy-info.svg"
-              />
-            </div>
-            <div
-              class="MuiBox-root-446 MuiBox-root-747"
-            >
-              <p
-                class="MuiTypography-root-182 makeStyles-projectedApr-444 MuiTypography-body1-184"
-              >
-                Current: 
-                7.61%
-              </p>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
-        >
-          <p
-            class="MuiTypography-root-182 MuiTypography-body1-184"
-          >
-            My Deposits
-          </p>
-          <div
-            class="MuiBox-root-446 MuiBox-root-750"
-          >
-            <p
-              class="MuiTypography-root-182 MuiTypography-body1-184"
-            >
-              $0
-            </p>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root-42 MuiGrid-item-44"
-      >
-        <div
-          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
-        >
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
-          >
-            <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
-            >
-              <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Aura
               </span>
@@ -5964,10 +4748,10 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 makeStyles-clickableTag-408 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 makeStyles-clickableTag-409 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Ecosystem Helper
               </span>
@@ -5977,7 +4761,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
@@ -5986,24 +4770,29 @@ exports[`Landing Renders tablet version correctly 1`] = `
           class="makeStyles-root-405"
         >
           <img
-            alt="renBTC logo"
-            class="makeStyles-position-751"
-            src="/assets/icons/renbtc.svg"
+            alt="auraBAL logo"
+            class="makeStyles-position-687"
+            src="/assets/icons/aurabal.svg"
           />
           <img
-            alt="WBTC logo"
-            class="makeStyles-position-752"
-            src="/assets/icons/wbtc.svg"
+            alt="graviAURA logo"
+            class="makeStyles-position-688"
+            src="/assets/icons/graviaura.svg"
+          />
+          <img
+            alt="WETH logo"
+            class="makeStyles-position-689"
+            src="/assets/icons/weth.svg"
           />
         </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
-          renBTC/wBTC
+          graviAURA/auraBAL/WETH
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -6014,21 +4803,31 @@ exports[`Landing Renders tablet version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-753 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-690 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-754 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-691 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                2.01%
+                56.93%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-692"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                95.64%
+              </p>
             </div>
           </div>
         </div>
@@ -6041,7 +4840,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-757"
+            class="MuiBox-root-447 MuiBox-root-695"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -6061,10 +4860,533 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-696"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="BADGER logo"
+            class="makeStyles-position-697"
+            src="/assets/icons/badger.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          BADGER/WBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-698 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-699 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                62.26%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-700"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                166.58%
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-703"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-704"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="DIGG logo"
+            class="makeStyles-position-705"
+            src="/assets/icons/digg.svg"
+          />
+          <img
+            alt="graviAURA logo"
+            class="makeStyles-position-706"
+            src="/assets/icons/graviaura.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          graviAURA/DIGG/WBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-707 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-708 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                43.99%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-709"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                5.08%
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-712"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="CVX logo"
+            class="makeStyles-position-713"
+            src="/assets/icons/cvx.svg"
+          />
+          <img
+            alt="bveCVX logo"
+            class="makeStyles-position-714"
+            src="/assets/icons/bvecvx.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          CVX/bveCVX
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-715 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-716 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                36.69%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-719"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Curve
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="wibBTC logo"
+            class="makeStyles-position-720"
+            src="/assets/icons/wibbtc.svg"
+          />
+          <img
+            alt="crvRenWSBTC logo"
+            class="makeStyles-position-721"
+            src="/assets/icons/crvrenwsbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          ibBTC/crvsBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-722 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-723 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                20.29%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-726"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Convex
+              </span>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                🚀 Boosted
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="BADGER logo"
+            class="makeStyles-position-727"
+            src="/assets/icons/badger.svg"
+          />
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-728"
+            src="/assets/icons/wbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          BADGER/WBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-729 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-730 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                4.77%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-733"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>
@@ -6074,7 +5396,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
       </div>
     </div>
     <div
-      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-653 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
     >
       <div
         class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
@@ -6083,29 +5405,24 @@ exports[`Landing Renders tablet version correctly 1`] = `
           class="makeStyles-root-405"
         >
           <img
-            alt="USDT logo"
-            class="makeStyles-position-758"
-            src="/assets/icons/usdt.svg"
-          />
-          <img
             alt="WBTC logo"
-            class="makeStyles-position-759"
+            class="makeStyles-position-734"
             src="/assets/icons/wbtc.svg"
           />
           <img
-            alt="WETH logo"
-            class="makeStyles-position-760"
-            src="/assets/icons/weth.svg"
+            alt="BADGER logo"
+            class="makeStyles-position-735"
+            src="/assets/icons/badger.svg"
           />
         </div>
         <h6
-          class="MuiTypography-root-182 makeStyles-name-655 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
         >
-          Tricrypto2
+          wBTC/Badger
         </h6>
       </div>
       <div
-        class="MuiGrid-root-42 makeStyles-info-654 MuiGrid-container-43 MuiGrid-item-44"
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
       >
         <div
           class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
@@ -6116,19 +5433,19 @@ exports[`Landing Renders tablet version correctly 1`] = `
             APY
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-761 makeStyles-root-440"
+            class="MuiBox-root-447 MuiBox-root-736 makeStyles-root-441"
           >
             <div
-              class="MuiBox-root-446 MuiBox-root-762 makeStyles-aprDisplay-443"
+              class="MuiBox-root-447 MuiBox-root-737 makeStyles-aprDisplay-444"
             >
               <p
                 class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
               >
-                14.58%
+                7.03%
               </p>
               <img
                 alt="apy info icon"
-                class="makeStyles-apyInfo-442"
+                class="makeStyles-apyInfo-443"
                 src="/assets/icons/apy-info.svg"
               />
             </div>
@@ -6143,7 +5460,7 @@ exports[`Landing Renders tablet version correctly 1`] = `
             My Deposits
           </p>
           <div
-            class="MuiBox-root-446 MuiBox-root-765"
+            class="MuiBox-root-447 MuiBox-root-740"
           >
             <p
               class="MuiTypography-root-182 MuiTypography-body1-184"
@@ -6163,10 +5480,510 @@ exports[`Landing Renders tablet version correctly 1`] = `
             class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
           >
             <div
-              class="MuiChip-root-410 makeStyles-tag-406 MuiChip-sizeSmall-411"
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
             >
               <span
-                class="MuiChip-label-432 MuiChip-labelSmall-433"
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Sushiswap
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-741"
+            src="/assets/icons/wbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          wBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-742 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-743 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                0.00%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-746"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Yearn
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-747"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="WETH logo"
+            class="makeStyles-position-748"
+            src="/assets/icons/weth.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          wBTC/wETH
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-749 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-750 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                2.23%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-753"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Sushiswap
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="bb-a-USDT logo"
+            class="makeStyles-position-754"
+            src="/assets/icons/bb-a-usdt.svg"
+          />
+          <img
+            alt="bb-a-DAI logo"
+            class="makeStyles-position-755"
+            src="/assets/icons/bb-a-dai.svg"
+          />
+          <img
+            alt="bb-a-USDC logo"
+            class="makeStyles-position-756"
+            src="/assets/icons/bb-a-usdc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          bb-a-USD
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-757 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-758 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                1.75%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+            <div
+              class="MuiBox-root-447 MuiBox-root-759"
+            >
+              <p
+                class="MuiTypography-root-182 makeStyles-projectedApr-445 MuiTypography-body1-184"
+              >
+                Current: 
+                6.89%
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-762"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Aura
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="renBTC logo"
+            class="makeStyles-position-763"
+            src="/assets/icons/renbtc.svg"
+          />
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-764"
+            src="/assets/icons/wbtc.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          renBTC/wBTC
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-765 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-766 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                0.92%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-769"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
+              >
+                Convex
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiPaper-root-14 MuiCard-root-404 MuiGrid-root-42 makeStyles-root-659 MuiGrid-container-43 MuiGrid-direction-xs-column-46 MuiPaper-elevation1-18 MuiPaper-rounded-15"
+    >
+      <div
+        class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="makeStyles-root-405"
+        >
+          <img
+            alt="USDT logo"
+            class="makeStyles-position-770"
+            src="/assets/icons/usdt.svg"
+          />
+          <img
+            alt="WBTC logo"
+            class="makeStyles-position-771"
+            src="/assets/icons/wbtc.svg"
+          />
+          <img
+            alt="WETH logo"
+            class="makeStyles-position-772"
+            src="/assets/icons/weth.svg"
+          />
+        </div>
+        <h6
+          class="MuiTypography-root-182 makeStyles-name-661 MuiTypography-subtitle1-193 MuiTypography-displayInline-210"
+        >
+          Tricrypto2
+        </h6>
+      </div>
+      <div
+        class="MuiGrid-root-42 makeStyles-info-660 MuiGrid-container-43 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            APY
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-773 makeStyles-root-441"
+          >
+            <div
+              class="MuiBox-root-447 MuiBox-root-774 makeStyles-aprDisplay-444"
+            >
+              <p
+                class="MuiTypography-root-182 MuiTypography-body1-184 MuiTypography-colorTextPrimary-207 MuiTypography-displayInline-210"
+              >
+                2.14%
+              </p>
+              <img
+                alt="apy info icon"
+                class="makeStyles-apyInfo-443"
+                src="/assets/icons/apy-info.svg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-item-44 MuiGrid-direction-xs-column-46 MuiGrid-grid-xs-true-76"
+        >
+          <p
+            class="MuiTypography-root-182 MuiTypography-body1-184"
+          >
+            My Deposits
+          </p>
+          <div
+            class="MuiBox-root-447 MuiBox-root-777"
+          >
+            <p
+              class="MuiTypography-root-182 MuiTypography-body1-184"
+            >
+              $0
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiGrid-root-42 MuiGrid-item-44"
+      >
+        <div
+          class="MuiGrid-root-42 MuiGrid-container-43 MuiGrid-spacing-xs-1-65"
+        >
+          <div
+            class="MuiGrid-root-42 MuiGrid-item-44 MuiGrid-grid-xs-auto-75"
+          >
+            <div
+              class="MuiChip-root-411 makeStyles-tag-407 MuiChip-sizeSmall-412"
+            >
+              <span
+                class="MuiChip-label-433 MuiChip-labelSmall-434"
               >
                 Convex
               </span>

--- a/src/tests/__snapshots__/VaultDeposit.test.tsx.snap
+++ b/src/tests/__snapshots__/VaultDeposit.test.tsx.snap
@@ -666,7 +666,7 @@ exports[`Vault Deposit displays sett information 1`] = `
                       %
                     </span>
                     <span
-                      class="MuiTouchRipple-root-340"
+                      class="MuiTouchRipple-root-324"
                     />
                   </button>
                   <button
@@ -682,7 +682,7 @@ exports[`Vault Deposit displays sett information 1`] = `
                       %
                     </span>
                     <span
-                      class="MuiTouchRipple-root-340"
+                      class="MuiTouchRipple-root-324"
                     />
                   </button>
                   <button
@@ -698,7 +698,7 @@ exports[`Vault Deposit displays sett information 1`] = `
                       %
                     </span>
                     <span
-                      class="MuiTouchRipple-root-340"
+                      class="MuiTouchRipple-root-324"
                     />
                   </button>
                   <button
@@ -714,7 +714,7 @@ exports[`Vault Deposit displays sett information 1`] = `
                       %
                     </span>
                     <span
-                      class="MuiTouchRipple-root-340"
+                      class="MuiTouchRipple-root-324"
                     />
                   </button>
                 </div>
@@ -724,72 +724,11 @@ exports[`Vault Deposit displays sett information 1`] = `
           <div
             class="makeStyles-fees-3"
           >
-            <div
-              class="MuiGrid-root-93 MuiGrid-container-94"
+            <p
+              class="MuiTypography-root-63 makeStyles-specName-316 MuiTypography-body1-65 MuiTypography-colorTextSecondary-89 MuiTypography-displayInline-91"
             >
-              <div
-                class="MuiGrid-root-93 makeStyles-feeRow-320 MuiGrid-container-94 MuiGrid-justify-content-xs-space-between-113"
-              >
-                <div
-                  class="MuiBox-root-196 MuiBox-root-321"
-                >
-                  <span
-                    class="MuiTypography-root-63 makeStyles-specName-318 MuiTypography-body1-65 MuiTypography-colorTextSecondary-89"
-                  >
-                    Performance Fee
-                     
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="see fees descriptions"
-                    class="MuiSvgIcon-root-198 makeStyles-helpIcon-319 MuiSvgIcon-colorPrimary-199"
-                    focusable="false"
-                    title="Click to see full description"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-                    />
-                  </svg>
-                </div>
-                <h6
-                  class="MuiTypography-root-63 MuiTypography-subtitle2-75 MuiTypography-displayInline-91"
-                >
-                  20%
-                </h6>
-              </div>
-              <div
-                class="MuiGrid-root-93 makeStyles-feeRow-320 MuiGrid-container-94 MuiGrid-justify-content-xs-space-between-113"
-              >
-                <div
-                  class="MuiBox-root-196 MuiBox-root-333"
-                >
-                  <span
-                    class="MuiTypography-root-63 makeStyles-specName-318 MuiTypography-body1-65 MuiTypography-colorTextSecondary-89"
-                  >
-                    Withdraw Fee
-                     
-                  </span>
-                  <svg
-                    aria-hidden="true"
-                    aria-label="see fees descriptions"
-                    class="MuiSvgIcon-root-198 makeStyles-helpIcon-319 MuiSvgIcon-colorPrimary-199"
-                    focusable="false"
-                    title="Click to see full description"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-                    />
-                  </svg>
-                </div>
-                <h6
-                  class="MuiTypography-root-63 MuiTypography-subtitle2-75 MuiTypography-displayInline-91"
-                >
-                  0.1%
-                </h6>
-              </div>
-            </div>
+              There are no fees for this vault
+            </p>
           </div>
           <div
             class="MuiGrid-root-93 makeStyles-totalAmountContainer-9 MuiGrid-container-94"
@@ -798,7 +737,7 @@ exports[`Vault Deposit displays sett information 1`] = `
               class="MuiGrid-root-93 MuiGrid-item-95 MuiGrid-grid-xs-6-133"
             >
               <div
-                class="MuiBox-root-196 MuiBox-root-334 makeStyles-totalAmountLabel-10"
+                class="MuiBox-root-196 MuiBox-root-318 makeStyles-totalAmountLabel-10"
               >
                 Total Deposit
               </div>
@@ -807,7 +746,7 @@ exports[`Vault Deposit displays sett information 1`] = `
               class="MuiGrid-root-93 MuiGrid-item-95 MuiGrid-grid-xs-6-133"
             >
               <div
-                class="MuiBox-root-196 MuiBox-root-335 makeStyles-totalAmount-11"
+                class="MuiBox-root-196 MuiBox-root-319 makeStyles-totalAmount-11"
               >
                 0
               </div>
@@ -815,7 +754,7 @@ exports[`Vault Deposit displays sett information 1`] = `
           </div>
           <button
             aria-label="Deposit"
-            class="MuiButtonBase-root-313 MuiButton-root-284 MuiButton-contained-292 WithStyles(ForwardRef(Button))-root-338 WithStyles(ForwardRef(Button))-root-339 Styled(WithStyles(ForwardRef(Button)))-root-336 Styled(WithStyles(ForwardRef(Button)))-root-337 MuiButton-containedPrimary-293 MuiButton-containedSizeLarge-304 MuiButton-sizeLarge-306 MuiButton-disabled-297 MuiButton-fullWidth-307 MuiButtonBase-disabled-314"
+            class="MuiButtonBase-root-313 MuiButton-root-284 MuiButton-contained-292 WithStyles(ForwardRef(Button))-root-322 WithStyles(ForwardRef(Button))-root-323 Styled(WithStyles(ForwardRef(Button)))-root-320 Styled(WithStyles(ForwardRef(Button)))-root-321 MuiButton-containedPrimary-293 MuiButton-containedSizeLarge-304 MuiButton-sizeLarge-306 MuiButton-disabled-297 MuiButton-fullWidth-307 MuiButtonBase-disabled-314"
             disabled=""
             tabindex="-1"
             type="button"

--- a/src/tests/__snapshots__/VaultWithdraw.test.tsx.snap
+++ b/src/tests/__snapshots__/VaultWithdraw.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`Vault Withdraw displays sett information 1`] = `
                 <p
                   class="MuiTypography-root-64 makeStyles-specName-323 MuiTypography-body1-66 MuiTypography-colorTextSecondary-90 MuiTypography-displayInline-92"
                 >
-                  Withdraw Fee (0.1%)
+                  Withdraw Fee (0%)
                 </p>
                 <h6
                   class="MuiTypography-root-64 MuiTypography-subtitle2-76 MuiTypography-displayInline-92"

--- a/src/tests/sett-details/__snapshots__/SpecsCard.test.tsx.snap
+++ b/src/tests/sett-details/__snapshots__/SpecsCard.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Specs Section displays sett information 1`] = `
           class="MuiTypography-root-146 makeStyles-amount-185 MuiTypography-body1-148"
         >
           $
-          258
+          225
         </p>
         <p
           class="MuiTypography-root-146 makeStyles-assetsText-145 MuiTypography-body2-147"
@@ -97,7 +97,7 @@ exports[`Specs Section displays sett information 1`] = `
             <h6
               class="MuiTypography-root-146 MuiTypography-subtitle2-158 MuiTypography-displayInline-174"
             >
-              0.0071
+              0.0075
             </h6>
           </div>
           <div
@@ -120,7 +120,7 @@ exports[`Specs Section displays sett information 1`] = `
             <h6
               class="MuiTypography-root-146 MuiTypography-subtitle2-158 MuiTypography-displayInline-174"
             >
-              0.0037
+              0.0033
             </h6>
           </div>
         </div>
@@ -192,79 +192,18 @@ exports[`Specs Section displays sett information 1`] = `
       class="MuiGrid-root-33 makeStyles-specSection-2 MuiGrid-item-35 MuiGrid-grid-xs-true-67"
     >
       <div>
-        <div
-          class="MuiGrid-root-33 MuiGrid-container-34"
+        <p
+          class="MuiTypography-root-146 makeStyles-specName-238 MuiTypography-body1-148 MuiTypography-colorTextSecondary-172 MuiTypography-displayInline-174"
         >
-          <div
-            class="MuiGrid-root-33 makeStyles-feeRow-242 MuiGrid-container-34 MuiGrid-justify-content-xs-space-between-53"
-          >
-            <div
-              class="MuiBox-root-194 MuiBox-root-243"
-            >
-              <span
-                class="MuiTypography-root-146 makeStyles-specName-240 MuiTypography-body1-148 MuiTypography-colorTextSecondary-172"
-              >
-                Performance Fee
-                 
-              </span>
-              <svg
-                aria-hidden="true"
-                aria-label="see fees descriptions"
-                class="MuiSvgIcon-root-214 makeStyles-helpIcon-241 MuiSvgIcon-colorPrimary-215"
-                focusable="false"
-                title="Click to see full description"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-                />
-              </svg>
-            </div>
-            <h6
-              class="MuiTypography-root-146 MuiTypography-subtitle2-158 MuiTypography-displayInline-174"
-            >
-              20%
-            </h6>
-          </div>
-          <div
-            class="MuiGrid-root-33 makeStyles-feeRow-242 MuiGrid-container-34 MuiGrid-justify-content-xs-space-between-53"
-          >
-            <div
-              class="MuiBox-root-194 MuiBox-root-255"
-            >
-              <span
-                class="MuiTypography-root-146 makeStyles-specName-240 MuiTypography-body1-148 MuiTypography-colorTextSecondary-172"
-              >
-                Withdraw Fee
-                 
-              </span>
-              <svg
-                aria-hidden="true"
-                aria-label="see fees descriptions"
-                class="MuiSvgIcon-root-214 makeStyles-helpIcon-241 MuiSvgIcon-colorPrimary-215"
-                focusable="false"
-                title="Click to see full description"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-                />
-              </svg>
-            </div>
-            <h6
-              class="MuiTypography-root-146 MuiTypography-subtitle2-158 MuiTypography-displayInline-174"
-            >
-              0.1%
-            </h6>
-          </div>
-        </div>
+          There are no fees for this vault
+        </p>
       </div>
     </div>
     <div
       class="MuiGrid-root-33 MuiGrid-item-35 MuiGrid-grid-xs-true-67"
     >
       <div
-        class="MuiGrid-root-33 makeStyles-linksContainer-258 MuiGrid-container-34"
+        class="MuiGrid-root-33 makeStyles-linksContainer-242 MuiGrid-container-34"
       >
         <p
           class="MuiTypography-root-146 MuiTypography-body1-148"
@@ -272,14 +211,14 @@ exports[`Specs Section displays sett information 1`] = `
           Links
         </p>
         <hr
-          class="MuiDivider-root-178 WithStyles(ForwardRef(Divider))-root-176 WithStyles(ForwardRef(Divider))-root-259"
+          class="MuiDivider-root-178 WithStyles(ForwardRef(Divider))-root-176 WithStyles(ForwardRef(Divider))-root-243"
         />
         <div
-          class="MuiGrid-root-33 makeStyles-linkContainer-260 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
+          class="MuiGrid-root-33 makeStyles-linkContainer-244 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-214 makeStyles-icon-262 MuiSvgIcon-colorPrimary-215"
+            class="MuiSvgIcon-root-214 makeStyles-icon-246 MuiSvgIcon-colorPrimary-215"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -288,7 +227,7 @@ exports[`Specs Section displays sett information 1`] = `
             />
           </svg>
           <a
-            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-261 MuiTypography-colorPrimary-169"
+            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-245 MuiTypography-colorPrimary-169"
             href="https://docs.badger.com/badger-finance/setts/sett-user-guides-ethereum/convex-bbtc"
             rel="noreferrer"
             target="_blank"
@@ -297,11 +236,11 @@ exports[`Specs Section displays sett information 1`] = `
           </a>
         </div>
         <div
-          class="MuiGrid-root-33 makeStyles-linkContainer-260 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
+          class="MuiGrid-root-33 makeStyles-linkContainer-244 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-214 makeStyles-icon-262 MuiSvgIcon-colorPrimary-215"
+            class="MuiSvgIcon-root-214 makeStyles-icon-246 MuiSvgIcon-colorPrimary-215"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -310,7 +249,7 @@ exports[`Specs Section displays sett information 1`] = `
             />
           </svg>
           <a
-            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-261 MuiTypography-colorPrimary-169"
+            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-245 MuiTypography-colorPrimary-169"
             href="https://badger.wiki/strategies#fe4a64edc830472da5a700d0fc30716c"
             rel="noreferrer"
             target="_blank"
@@ -319,11 +258,11 @@ exports[`Specs Section displays sett information 1`] = `
           </a>
         </div>
         <div
-          class="MuiGrid-root-33 makeStyles-linkContainer-260 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
+          class="MuiGrid-root-33 makeStyles-linkContainer-244 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-214 makeStyles-icon-262 MuiSvgIcon-colorPrimary-215"
+            class="MuiSvgIcon-root-214 makeStyles-icon-246 MuiSvgIcon-colorPrimary-215"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -332,7 +271,7 @@ exports[`Specs Section displays sett information 1`] = `
             />
           </svg>
           <a
-            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-261 MuiTypography-colorPrimary-169"
+            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-245 MuiTypography-colorPrimary-169"
             href="https://curve.fi/bbtc/deposit"
             rel="noreferrer"
             target="_blank"
@@ -341,11 +280,11 @@ exports[`Specs Section displays sett information 1`] = `
           </a>
         </div>
         <div
-          class="MuiGrid-root-33 makeStyles-linkContainer-260 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
+          class="MuiGrid-root-33 makeStyles-linkContainer-244 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-214 makeStyles-icon-262 MuiSvgIcon-colorPrimary-215"
+            class="MuiSvgIcon-root-214 makeStyles-icon-246 MuiSvgIcon-colorPrimary-215"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -354,7 +293,7 @@ exports[`Specs Section displays sett information 1`] = `
             />
           </svg>
           <a
-            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-261 MuiTypography-colorPrimary-169"
+            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-245 MuiTypography-colorPrimary-169"
             href="https://etherscan.io/address/0x5Dce29e92b1b939F8E8C60DcF15BDE82A85be4a9"
             rel="noreferrer"
             target="_blank"
@@ -363,11 +302,11 @@ exports[`Specs Section displays sett information 1`] = `
           </a>
         </div>
         <div
-          class="MuiGrid-root-33 makeStyles-linkContainer-260 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
+          class="MuiGrid-root-33 makeStyles-linkContainer-244 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-214 makeStyles-icon-262 MuiSvgIcon-colorPrimary-215"
+            class="MuiSvgIcon-root-214 makeStyles-icon-246 MuiSvgIcon-colorPrimary-215"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -376,8 +315,8 @@ exports[`Specs Section displays sett information 1`] = `
             />
           </svg>
           <a
-            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-261 MuiTypography-colorPrimary-169"
-            href="https://etherscan.io/address/0xF2F3AB09E2D8986fBECbBa59aE838a5418a6680c"
+            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-245 MuiTypography-colorPrimary-169"
+            href="https://etherscan.io/address/0x0000000000000000000000000000000000000000"
             rel="noreferrer"
             target="_blank"
           >
@@ -385,11 +324,11 @@ exports[`Specs Section displays sett information 1`] = `
           </a>
         </div>
         <div
-          class="MuiGrid-root-33 makeStyles-linkContainer-260 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
+          class="MuiGrid-root-33 makeStyles-linkContainer-244 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-214 makeStyles-icon-262 MuiSvgIcon-colorPrimary-215"
+            class="MuiSvgIcon-root-214 makeStyles-icon-246 MuiSvgIcon-colorPrimary-215"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -398,7 +337,7 @@ exports[`Specs Section displays sett information 1`] = `
             />
           </svg>
           <a
-            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-261 MuiTypography-colorPrimary-169"
+            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-245 MuiTypography-colorPrimary-169"
             href="https://etherscan.io/address/0x410e3E86ef427e30B9235497143881f717d93c2A"
             rel="noreferrer"
             target="_blank"
@@ -407,11 +346,11 @@ exports[`Specs Section displays sett information 1`] = `
           </a>
         </div>
         <div
-          class="MuiGrid-root-33 makeStyles-linkContainer-260 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
+          class="MuiGrid-root-33 makeStyles-linkContainer-244 MuiGrid-container-34 MuiGrid-align-items-xs-center-42"
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-214 makeStyles-icon-262 MuiSvgIcon-colorPrimary-215"
+            class="MuiSvgIcon-root-214 makeStyles-icon-246 MuiSvgIcon-colorPrimary-215"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -420,7 +359,7 @@ exports[`Specs Section displays sett information 1`] = `
             />
           </svg>
           <a
-            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-261 MuiTypography-colorPrimary-169"
+            class="MuiTypography-root-146 MuiLink-root-208 MuiLink-underlineHover-210 makeStyles-link-245 MuiTypography-colorPrimary-169"
             href="https://badger-ninja.vercel.app/vault/ethereum/0x5Dce29e92b1b939F8E8C60DcF15BDE82A85be4a9"
             rel="noreferrer"
             target="_blank"

--- a/src/tests/vaults/__snapshots__/VaultItemApr.test.tsx.snap
+++ b/src/tests/vaults/__snapshots__/VaultItemApr.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`VaultItemApr No APR Vaults renders zero APR 1`] = `
       <p
         class="MuiTypography-root-10 MuiTypography-body1-12 MuiTypography-colorTextPrimary-35 MuiTypography-displayInline-38"
       >
-        0.31%
+        0.00%
       </p>
       <img
         alt="apy info icon"

--- a/src/tests/vaults/__snapshots__/VaultItemApr.test.tsx.snap
+++ b/src/tests/vaults/__snapshots__/VaultItemApr.test.tsx.snap
@@ -25,10 +25,23 @@ exports[`VaultItemApr Boosted Vaults displays correct APR and boost information 
 
 exports[`VaultItemApr No APR Vaults renders zero APR 1`] = `
 <div>
-  <p
-    class="MuiTypography-root-7 makeStyles-apr-2 MuiTypography-body1-9 MuiTypography-colorTextPrimary-32"
+  <div
+    class="MuiBox-root-7 MuiBox-root-8 makeStyles-root-1"
   >
-    --%
-  </p>
+    <div
+      class="MuiBox-root-7 MuiBox-root-9 makeStyles-aprDisplay-4"
+    >
+      <p
+        class="MuiTypography-root-10 MuiTypography-body1-12 MuiTypography-colorTextPrimary-35 MuiTypography-displayInline-38"
+      >
+        0.31%
+      </p>
+      <img
+        alt="apy info icon"
+        class="makeStyles-apyInfo-3"
+        src="/assets/icons/apy-info.svg"
+      />
+    </div>
+  </div>
 </div>
 `;

--- a/src/tests/vaults/__snapshots__/VaultListDisplay.test.tsx.snap
+++ b/src/tests/vaults/__snapshots__/VaultListDisplay.test.tsx.snap
@@ -225,7 +225,9 @@ exports[`VaultListDisplay displays no vaults message 1`] = `
       <h5
         class="MuiTypography-root-111 MuiTypography-h5-120 MuiTypography-colorTextSecondary-137"
       >
-        No vaults to display
+        No vaults on $
+        ethereum
+        .
       </h5>
       <p
         class="MuiTypography-root-111 MuiTypography-body2-112 MuiTypography-colorTextSecondary-137"
@@ -274,7 +276,9 @@ exports[`VaultListDisplay does not display deprecated vaults with no user balanc
       <h5
         class="MuiTypography-root-111 MuiTypography-h5-120 MuiTypography-colorTextSecondary-137"
       >
-        No vaults to display
+        No vaults on $
+        ethereum
+        .
       </h5>
       <p
         class="MuiTypography-root-111 MuiTypography-body2-112 MuiTypography-colorTextSecondary-137"
@@ -339,7 +343,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </span>
           <span
-            class="MuiTouchRipple-root-454"
+            class="MuiTouchRipple-root-462"
           />
         </button>
       </div>
@@ -367,7 +371,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </span>
           <span
-            class="MuiTouchRipple-root-454"
+            class="MuiTouchRipple-root-462"
           />
         </button>
       </div>
@@ -395,7 +399,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </span>
           <span
-            class="MuiTouchRipple-root-454"
+            class="MuiTouchRipple-root-462"
           />
         </button>
       </div>
@@ -423,7 +427,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </span>
           <span
-            class="MuiTouchRipple-root-454"
+            class="MuiTouchRipple-root-462"
           />
         </button>
       </div>
@@ -490,17 +494,30 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
-        <p
-          class="MuiTypography-root-144 makeStyles-apr-233 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169"
+        <div
+          class="MuiBox-root-238 MuiBox-root-239 makeStyles-root-232"
         >
-          --%
-        </p>
+          <div
+            class="MuiBox-root-238 MuiBox-root-240 makeStyles-aprDisplay-235"
+          >
+            <p
+              class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
+            >
+              0.00%
+            </p>
+            <img
+              alt="apy info icon"
+              class="makeStyles-apyInfo-234"
+              src="/assets/icons/apy-info.svg"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-241"
+          class="MuiBox-root-238 MuiBox-root-285"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -513,12 +530,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-245"
+          class="MuiBox-root-238 MuiBox-root-289"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $1,061,884
+            $385,910
           </p>
         </div>
       </div>
@@ -535,7 +552,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
       >
         <div
           class="makeStyles-root-196"
-        />
+        >
+          <img
+            alt="CVX logo"
+            class="makeStyles-position-290"
+            src="/assets/icons/cvx.svg"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-grid-xs-true-47 MuiGrid-grid-lg-5-94"
@@ -567,15 +590,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-246 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-291 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-247 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-292 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              28.04%
+              28.32%
             </p>
             <img
               alt="apy info icon"
@@ -589,7 +612,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-292"
+          class="MuiBox-root-238 MuiBox-root-295"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -602,12 +625,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-295"
+          class="MuiBox-root-238 MuiBox-root-298"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $18,108,361
+            $13,738,345
           </p>
         </div>
       </div>
@@ -624,7 +647,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
       >
         <div
           class="makeStyles-root-196"
-        />
+        >
+          <img
+            alt="AURA logo"
+            class="makeStyles-position-299"
+            src="/assets/icons/aura.svg"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-grid-xs-true-47 MuiGrid-grid-lg-5-94"
@@ -656,15 +685,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-296 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-300 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-297 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-301 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              17.62%
+              80.91%
             </p>
             <img
               alt="apy info icon"
@@ -678,7 +707,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-300"
+          class="MuiBox-root-238 MuiBox-root-304"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -691,12 +720,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-303"
+          class="MuiBox-root-238 MuiBox-root-307"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $2,525,602
+            $2,753,168
           </p>
         </div>
       </div>
@@ -713,7 +742,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
       >
         <div
           class="makeStyles-root-196"
-        />
+        >
+          <img
+            alt="auraBAL logo"
+            class="makeStyles-position-308"
+            src="/assets/icons/aurabal.svg"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-grid-xs-true-47 MuiGrid-grid-lg-5-94"
@@ -726,19 +761,6 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         <div
           class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-spacing-xs-2-37"
         >
-          <div
-            class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
-          >
-            <div
-              class="MuiChip-root-202 makeStyles-tag-198 makeStyles-clickableTag-200 MuiChip-sizeSmall-203"
-            >
-              <span
-                class="MuiChip-label-224 MuiChip-labelSmall-225"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
           <div
             class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
           >
@@ -771,20 +793,16 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-304 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-309 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-305 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-310 makeStyles-aprDisplay-235"
           >
-            <h6
-              class="MuiTypography-root-144 MuiTypography-subtitle1-155 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
+            <p
+              class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              <img
-                alt="New Vault"
-                src="assets/icons/new-vault.svg"
-              />
-               New Vault
-            </h6>
+              14.91%
+            </p>
             <img
               alt="apy info icon"
               class="makeStyles-apyInfo-234"
@@ -792,13 +810,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </div>
           <div
-            class="MuiBox-root-240 MuiBox-root-306"
+            class="MuiBox-root-238 MuiBox-root-311"
           >
             <p
               class="MuiTypography-root-144 makeStyles-projectedApr-236 MuiTypography-body1-146"
             >
               Current: 
-              109.00%
+              65.00%
             </p>
           </div>
         </div>
@@ -807,7 +825,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-309"
+          class="MuiBox-root-238 MuiBox-root-314"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -820,12 +838,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-312"
+          class="MuiBox-root-238 MuiBox-root-317"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $69,939
+            $836,428
           </p>
         </div>
       </div>
@@ -845,17 +863,17 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="auraBAL logo"
-            class="makeStyles-position-313"
+            class="makeStyles-position-318"
             src="/assets/icons/aurabal.svg"
           />
           <img
             alt="graviAURA logo"
-            class="makeStyles-position-314"
+            class="makeStyles-position-319"
             src="/assets/icons/graviaura.svg"
           />
           <img
             alt="WETH logo"
-            class="makeStyles-position-315"
+            class="makeStyles-position-320"
             src="/assets/icons/weth.svg"
           />
         </div>
@@ -875,19 +893,6 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
           >
             <div
-              class="MuiChip-root-202 makeStyles-tag-198 makeStyles-clickableTag-200 MuiChip-sizeSmall-203"
-            >
-              <span
-                class="MuiChip-label-224 MuiChip-labelSmall-225"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
-          >
-            <div
               class="MuiChip-root-202 makeStyles-tag-198 MuiChip-sizeSmall-203"
             >
               <span
@@ -903,20 +908,16 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-316 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-321 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-317 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-322 makeStyles-aprDisplay-235"
           >
-            <h6
-              class="MuiTypography-root-144 MuiTypography-subtitle1-155 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
+            <p
+              class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              <img
-                alt="New Vault"
-                src="assets/icons/new-vault.svg"
-              />
-               New Vault
-            </h6>
+              56.93%
+            </p>
             <img
               alt="apy info icon"
               class="makeStyles-apyInfo-234"
@@ -924,13 +925,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </div>
           <div
-            class="MuiBox-root-240 MuiBox-root-318"
+            class="MuiBox-root-238 MuiBox-root-323"
           >
             <p
               class="MuiTypography-root-144 makeStyles-projectedApr-236 MuiTypography-body1-146"
             >
               Current: 
-              161.03%
+              95.64%
             </p>
           </div>
         </div>
@@ -939,7 +940,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-321"
+          class="MuiBox-root-238 MuiBox-root-326"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -952,12 +953,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-324"
+          class="MuiBox-root-238 MuiBox-root-329"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $73,432
+            $106,996
           </p>
         </div>
       </div>
@@ -977,12 +978,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="WBTC logo"
-            class="makeStyles-position-325"
+            class="makeStyles-position-330"
             src="/assets/icons/wbtc.svg"
           />
           <img
             alt="BADGER logo"
-            class="makeStyles-position-326"
+            class="makeStyles-position-331"
             src="/assets/icons/badger.svg"
           />
         </div>
@@ -1002,19 +1003,6 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
           >
             <div
-              class="MuiChip-root-202 makeStyles-tag-198 makeStyles-clickableTag-200 MuiChip-sizeSmall-203"
-            >
-              <span
-                class="MuiChip-label-224 MuiChip-labelSmall-225"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
-          >
-            <div
               class="MuiChip-root-202 makeStyles-tag-198 MuiChip-sizeSmall-203"
             >
               <span
@@ -1030,20 +1018,16 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-327 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-332 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-328 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-333 makeStyles-aprDisplay-235"
           >
-            <h6
-              class="MuiTypography-root-144 MuiTypography-subtitle1-155 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
+            <p
+              class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              <img
-                alt="New Vault"
-                src="assets/icons/new-vault.svg"
-              />
-               New Vault
-            </h6>
+              62.26%
+            </p>
             <img
               alt="apy info icon"
               class="makeStyles-apyInfo-234"
@@ -1051,13 +1035,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </div>
           <div
-            class="MuiBox-root-240 MuiBox-root-329"
+            class="MuiBox-root-238 MuiBox-root-334"
           >
             <p
               class="MuiTypography-root-144 makeStyles-projectedApr-236 MuiTypography-body1-146"
             >
               Current: 
-              34.29%
+              166.58%
             </p>
           </div>
         </div>
@@ -1066,7 +1050,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-332"
+          class="MuiBox-root-238 MuiBox-root-337"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1079,12 +1063,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-335"
+          class="MuiBox-root-238 MuiBox-root-340"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $544,871
+            $2,739,793
           </p>
         </div>
       </div>
@@ -1104,17 +1088,17 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="WBTC logo"
-            class="makeStyles-position-336"
+            class="makeStyles-position-341"
             src="/assets/icons/wbtc.svg"
           />
           <img
             alt="DIGG logo"
-            class="makeStyles-position-337"
+            class="makeStyles-position-342"
             src="/assets/icons/digg.svg"
           />
           <img
             alt="graviAURA logo"
-            class="makeStyles-position-338"
+            class="makeStyles-position-343"
             src="/assets/icons/graviaura.svg"
           />
         </div>
@@ -1134,19 +1118,6 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
           >
             <div
-              class="MuiChip-root-202 makeStyles-tag-198 makeStyles-clickableTag-200 MuiChip-sizeSmall-203"
-            >
-              <span
-                class="MuiChip-label-224 MuiChip-labelSmall-225"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
-          >
-            <div
               class="MuiChip-root-202 makeStyles-tag-198 MuiChip-sizeSmall-203"
             >
               <span
@@ -1162,20 +1133,16 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-339 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-344 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-340 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-345 makeStyles-aprDisplay-235"
           >
-            <h6
-              class="MuiTypography-root-144 MuiTypography-subtitle1-155 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
+            <p
+              class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              <img
-                alt="New Vault"
-                src="assets/icons/new-vault.svg"
-              />
-               New Vault
-            </h6>
+              43.99%
+            </p>
             <img
               alt="apy info icon"
               class="makeStyles-apyInfo-234"
@@ -1183,13 +1150,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </div>
           <div
-            class="MuiBox-root-240 MuiBox-root-341"
+            class="MuiBox-root-238 MuiBox-root-346"
           >
             <p
               class="MuiTypography-root-144 makeStyles-projectedApr-236 MuiTypography-body1-146"
             >
               Current: 
-              297.48%
+              5.08%
             </p>
           </div>
         </div>
@@ -1198,7 +1165,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-344"
+          class="MuiBox-root-238 MuiBox-root-349"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1211,12 +1178,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-347"
+          class="MuiBox-root-238 MuiBox-root-352"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $798,703
+            $744,657
           </p>
         </div>
       </div>
@@ -1236,12 +1203,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="CVX logo"
-            class="makeStyles-position-348"
+            class="makeStyles-position-353"
             src="/assets/icons/cvx.svg"
           />
           <img
             alt="bveCVX logo"
-            class="makeStyles-position-349"
+            class="makeStyles-position-354"
             src="/assets/icons/bvecvx.svg"
           />
         </div>
@@ -1276,15 +1243,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-350 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-355 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-351 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-356 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              20.46%
+              36.69%
             </p>
             <img
               alt="apy info icon"
@@ -1298,7 +1265,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-354"
+          class="MuiBox-root-238 MuiBox-root-359"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1311,12 +1278,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-357"
+          class="MuiBox-root-238 MuiBox-root-362"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $1,232,538
+            $832,345
           </p>
         </div>
       </div>
@@ -1333,7 +1300,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
       >
         <div
           class="makeStyles-root-196"
-        />
+        >
+          <img
+            alt="cvxCRV logo"
+            class="makeStyles-position-363"
+            src="/assets/icons/cvxcrv.svg"
+          />
+        </div>
       </div>
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-grid-xs-true-47 MuiGrid-grid-lg-5-94"
@@ -1391,15 +1364,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-358 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-364 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-359 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-365 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              26.63%
+              18.48%
             </p>
             <img
               alt="apy info icon"
@@ -1413,7 +1386,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-362"
+          class="MuiBox-root-238 MuiBox-root-368"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1426,12 +1399,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-365"
+          class="MuiBox-root-238 MuiBox-root-371"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $5,841,390
+            $3,609,918
           </p>
         </div>
       </div>
@@ -1451,12 +1424,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="wibBTC logo"
-            class="makeStyles-position-366"
+            class="makeStyles-position-372"
             src="/assets/icons/wibbtc.svg"
           />
           <img
             alt="crvRenWSBTC logo"
-            class="makeStyles-position-367"
+            class="makeStyles-position-373"
             src="/assets/icons/crvrenwsbtc.svg"
           />
         </div>
@@ -1504,15 +1477,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-368 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-374 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-369 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-375 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              16.77%
+              20.27%
             </p>
             <img
               alt="apy info icon"
@@ -1526,7 +1499,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-372"
+          class="MuiBox-root-238 MuiBox-root-378"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1539,12 +1512,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-375"
+          class="MuiBox-root-238 MuiBox-root-381"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $27,471,043
+            $19,814,734
           </p>
         </div>
       </div>
@@ -1564,12 +1537,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="BADGER logo"
-            class="makeStyles-position-376"
+            class="makeStyles-position-382"
             src="/assets/icons/badger.svg"
           />
           <img
             alt="WBTC logo"
-            class="makeStyles-position-377"
+            class="makeStyles-position-383"
             src="/assets/icons/wbtc.svg"
           />
         </div>
@@ -1604,15 +1577,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-378 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-384 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-379 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-385 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              19.15%
+              4.77%
             </p>
             <img
               alt="apy info icon"
@@ -1626,7 +1599,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-382"
+          class="MuiBox-root-238 MuiBox-root-388"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1639,12 +1612,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-385"
+          class="MuiBox-root-238 MuiBox-root-391"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $3,998,480
+            $2,708,612
           </p>
         </div>
       </div>
@@ -1664,12 +1637,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="WBTC logo"
-            class="makeStyles-position-386"
+            class="makeStyles-position-392"
             src="/assets/icons/wbtc.svg"
           />
           <img
             alt="BADGER logo"
-            class="makeStyles-position-387"
+            class="makeStyles-position-393"
             src="/assets/icons/badger.svg"
           />
         </div>
@@ -1704,15 +1677,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-388 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-394 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-389 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-395 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              21.17%
+              7.03%
             </p>
             <img
               alt="apy info icon"
@@ -1726,7 +1699,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-392"
+          class="MuiBox-root-238 MuiBox-root-398"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1739,12 +1712,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-395"
+          class="MuiBox-root-238 MuiBox-root-401"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $1,530,831
+            $1,224,135
           </p>
         </div>
       </div>
@@ -1764,7 +1737,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="WBTC logo"
-            class="makeStyles-position-396"
+            class="makeStyles-position-402"
             src="/assets/icons/wbtc.svg"
           />
         </div>
@@ -1798,17 +1771,30 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
-        <p
-          class="MuiTypography-root-144 makeStyles-apr-233 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169"
+        <div
+          class="MuiBox-root-238 MuiBox-root-403 makeStyles-root-232"
         >
-          --%
-        </p>
+          <div
+            class="MuiBox-root-238 MuiBox-root-404 makeStyles-aprDisplay-235"
+          >
+            <p
+              class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
+            >
+              0.00%
+            </p>
+            <img
+              alt="apy info icon"
+              class="makeStyles-apyInfo-234"
+              src="/assets/icons/apy-info.svg"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-399"
+          class="MuiBox-root-238 MuiBox-root-407"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1821,12 +1807,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-402"
+          class="MuiBox-root-238 MuiBox-root-410"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $2,942,012
+            $1,565,378
           </p>
         </div>
       </div>
@@ -1846,12 +1832,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="WBTC logo"
-            class="makeStyles-position-403"
+            class="makeStyles-position-411"
             src="/assets/icons/wbtc.svg"
           />
           <img
             alt="WETH logo"
-            class="makeStyles-position-404"
+            class="makeStyles-position-412"
             src="/assets/icons/weth.svg"
           />
         </div>
@@ -1886,15 +1872,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-405 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-413 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-406 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-414 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              2.60%
+              2.23%
             </p>
             <img
               alt="apy info icon"
@@ -1908,7 +1894,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-409"
+          class="MuiBox-root-238 MuiBox-root-417"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -1921,12 +1907,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-412"
+          class="MuiBox-root-238 MuiBox-root-420"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $9,057,468
+            $7,835,152
           </p>
         </div>
       </div>
@@ -1946,17 +1932,17 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="bb-a-USDT logo"
-            class="makeStyles-position-413"
+            class="makeStyles-position-421"
             src="/assets/icons/bb-a-usdt.svg"
           />
           <img
             alt="bb-a-DAI logo"
-            class="makeStyles-position-414"
+            class="makeStyles-position-422"
             src="/assets/icons/bb-a-dai.svg"
           />
           <img
             alt="bb-a-USDC logo"
-            class="makeStyles-position-415"
+            class="makeStyles-position-423"
             src="/assets/icons/bb-a-usdc.svg"
           />
         </div>
@@ -1976,19 +1962,6 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
           >
             <div
-              class="MuiChip-root-202 makeStyles-tag-198 makeStyles-clickableTag-200 MuiChip-sizeSmall-203"
-            >
-              <span
-                class="MuiChip-label-224 MuiChip-labelSmall-225"
-              >
-                experimental
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
-          >
-            <div
               class="MuiChip-root-202 makeStyles-tag-198 MuiChip-sizeSmall-203"
             >
               <span
@@ -1998,39 +1971,22 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
               </span>
             </div>
           </div>
-          <div
-            class="MuiGrid-root-13 MuiGrid-item-15 MuiGrid-grid-xs-auto-46"
-          >
-            <div
-              class="MuiChip-root-202 makeStyles-tag-198 makeStyles-clickableTag-200 MuiChip-sizeSmall-203"
-            >
-              <span
-                class="MuiChip-label-224 MuiChip-labelSmall-225"
-              >
-                Ecosystem Helper
-              </span>
-            </div>
-          </div>
         </div>
       </div>
       <div
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-416 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-424 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-417 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-425 makeStyles-aprDisplay-235"
           >
-            <h6
-              class="MuiTypography-root-144 MuiTypography-subtitle1-155 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
+            <p
+              class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              <img
-                alt="New Vault"
-                src="assets/icons/new-vault.svg"
-              />
-               New Vault
-            </h6>
+              1.75%
+            </p>
             <img
               alt="apy info icon"
               class="makeStyles-apyInfo-234"
@@ -2038,13 +1994,13 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
             />
           </div>
           <div
-            class="MuiBox-root-240 MuiBox-root-418"
+            class="MuiBox-root-238 MuiBox-root-426"
           >
             <p
               class="MuiTypography-root-144 makeStyles-projectedApr-236 MuiTypography-body1-146"
             >
               Current: 
-              7.61%
+              6.89%
             </p>
           </div>
         </div>
@@ -2053,7 +2009,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-421"
+          class="MuiBox-root-238 MuiBox-root-429"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -2066,12 +2022,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-424"
+          class="MuiBox-root-238 MuiBox-root-432"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $101,577
+            $204,737
           </p>
         </div>
       </div>
@@ -2091,12 +2047,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="renBTC logo"
-            class="makeStyles-position-425"
+            class="makeStyles-position-433"
             src="/assets/icons/renbtc.svg"
           />
           <img
             alt="WBTC logo"
-            class="makeStyles-position-426"
+            class="makeStyles-position-434"
             src="/assets/icons/wbtc.svg"
           />
         </div>
@@ -2131,15 +2087,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-427 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-435 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-428 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-436 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              2.01%
+              0.92%
             </p>
             <img
               alt="apy info icon"
@@ -2153,7 +2109,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-431"
+          class="MuiBox-root-238 MuiBox-root-439"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -2166,12 +2122,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-434"
+          class="MuiBox-root-238 MuiBox-root-442"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $18,683,481
+            $13,628,486
           </p>
         </div>
       </div>
@@ -2191,17 +2147,17 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         >
           <img
             alt="USDT logo"
-            class="makeStyles-position-435"
+            class="makeStyles-position-443"
             src="/assets/icons/usdt.svg"
           />
           <img
             alt="WBTC logo"
-            class="makeStyles-position-436"
+            class="makeStyles-position-444"
             src="/assets/icons/wbtc.svg"
           />
           <img
             alt="WETH logo"
-            class="makeStyles-position-437"
+            class="makeStyles-position-445"
             src="/assets/icons/weth.svg"
           />
         </div>
@@ -2236,15 +2192,15 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-align-items-xs-center-22 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-438 makeStyles-root-232"
+          class="MuiBox-root-238 MuiBox-root-446 makeStyles-root-232"
         >
           <div
-            class="MuiBox-root-240 MuiBox-root-439 makeStyles-aprDisplay-235"
+            class="MuiBox-root-238 MuiBox-root-447 makeStyles-aprDisplay-235"
           >
             <p
               class="MuiTypography-root-144 MuiTypography-body1-146 MuiTypography-colorTextPrimary-169 MuiTypography-displayInline-172"
             >
-              14.58%
+              2.14%
             </p>
             <img
               alt="apy info icon"
@@ -2258,7 +2214,7 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-442"
+          class="MuiBox-root-238 MuiBox-root-450"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
@@ -2271,12 +2227,12 @@ exports[`VaultListDisplay uses default sort criteria by default 1`] = `
         class="MuiGrid-root-13 MuiGrid-container-14 MuiGrid-item-15 MuiGrid-justify-content-xs-flex-end-32 MuiGrid-grid-xs-true-47"
       >
         <div
-          class="MuiBox-root-240 MuiBox-root-445"
+          class="MuiBox-root-238 MuiBox-root-453"
         >
           <p
             class="MuiTypography-root-144 makeStyles-itemText-188 MuiTypography-body1-146"
           >
-            $893,363
+            $817,047
           </p>
         </div>
       </div>

--- a/src/tests/vaults/__snapshots__/VaultMetrics.test.tsx.snap
+++ b/src/tests/vaults/__snapshots__/VaultMetrics.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`VaultMetrics displays withdrawable tokens 1`] = `
       class="MuiTypography-root-114 makeStyles-amount-153 MuiTypography-body1-116"
     >
       $
-      258
+      225
     </p>
     <p
       class="MuiTypography-root-114 makeStyles-assetsText-10 MuiTypography-body2-115"
@@ -87,7 +87,7 @@ exports[`VaultMetrics renders correctly 1`] = `
       class="MuiTypography-root-114 makeStyles-amount-153 MuiTypography-body1-116"
     >
       $
-      258
+      225
     </p>
     <p
       class="MuiTypography-root-114 makeStyles-assetsText-10 MuiTypography-body2-115"


### PR DESCRIPTION
# Summary

- ensure `baseYield` usage is removed
- utilize `grossYield` for all displays