### PR TITLE
feat: provide a 'go to balancer' button on the ui when depositing

### DIFF
--- a/src/components-v2/vault-detail/TopContent.tsx
+++ b/src/components-v2/vault-detail/TopContent.tsx
@@ -1,5 +1,6 @@
 import { VaultDTOV3, VaultState } from '@badger-dao/sdk';
 import { Grid, makeStyles } from '@material-ui/core';
+
 import VaultDeprecationWarning from '../VaultDeprecationWarning';
 import { Breadcrumb } from './Breadcrumb';
 import { Description } from './description/Description';

--- a/src/components-v2/vault-detail/TopContent.tsx
+++ b/src/components-v2/vault-detail/TopContent.tsx
@@ -1,7 +1,5 @@
 import { VaultDTOV3, VaultState } from '@badger-dao/sdk';
 import { Grid, makeStyles } from '@material-ui/core';
-import React from 'react';
-
 import VaultDeprecationWarning from '../VaultDeprecationWarning';
 import { Breadcrumb } from './Breadcrumb';
 import { Description } from './description/Description';
@@ -13,20 +11,11 @@ const useStyles = makeStyles((theme) => ({
       marginBottom: theme.spacing(2),
     },
   },
-  content: {
-    margin: 'auto',
-    [theme.breakpoints.up('md')]: {
-      marginTop: theme.spacing(2),
-    },
-  },
   descriptionSection: {
     justifyContent: 'space-between',
   },
   breadcrumbContainer: {
     marginBottom: theme.spacing(1),
-  },
-  holdingsContainer: {
-    marginBottom: theme.spacing(2),
   },
 }));
 

--- a/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
+++ b/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
@@ -38,8 +38,8 @@ export const MobileStickyActionButtons = observer(({ vault, onDepositClick, onWi
   const canUserDeposit = wallet.isConnected ? vaults.canUserDeposit(vault) : false;
   const canUserWithdraw = vaults.canUserWithdraw(vault);
   const { depositBalance } = useVaultInformation(vault);
-  const isUserHasToken = user.getBalance(vault.underlyingToken).hasBalance();
-  const isUserHasDeposit = !depositBalance.tokenBalance.eq(0);
+  const userHasToken = user.getBalance(vault.underlyingToken).hasBalance();
+  const userHasDeposit = !depositBalance.tokenBalance.eq(0);
   const { network } = networkStore;
   const strategy = Chain.getChain(network).strategies[vault.vaultToken];
 
@@ -47,7 +47,7 @@ export const MobileStickyActionButtons = observer(({ vault, onDepositClick, onWi
     <div className={classes.root}>
       <Grid container spacing={1}>
         <Grid item xs>
-          {isUserHasToken ? (
+          {userHasToken ? (
             <VaultActionButton
               fullWidth
               color="primary"
@@ -65,7 +65,7 @@ export const MobileStickyActionButtons = observer(({ vault, onDepositClick, onWi
             </Link>
           )}
         </Grid>
-        {isUserHasDeposit && (
+        {userHasDeposit && (
           <Grid item xs>
             <VaultActionButton
               color="primary"

--- a/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
+++ b/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import { useVaultInformation } from 'hooks/useVaultInformation';
 import { Chain } from 'mobx/model/network/chain';
+import { goToProtocol } from '../utils';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -60,7 +61,7 @@ export const MobileStickyActionButtons = observer(({ vault, onDepositClick, onWi
           ) : (
             <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
               <VaultActionButton variant="contained" fullWidth color="primary">
-                Go to {vault.protocol}
+                Go to {goToProtocol(vault.protocol?.toLowerCase())}
               </VaultActionButton>
             </Link>
           )}

--- a/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
+++ b/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
@@ -1,13 +1,13 @@
 import { VaultDTOV3 } from '@badger-dao/sdk';
 import { Grid, Link } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { useVaultInformation } from 'hooks/useVaultInformation';
+import { Chain } from 'mobx/model/network/chain';
 import { StoreContext } from 'mobx/stores/store-context';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
 
 import { VaultActionButton } from '../../common/VaultActionButtons';
-import { useVaultInformation } from 'hooks/useVaultInformation';
-import { Chain } from 'mobx/model/network/chain';
 import { getGoToText } from '../utils';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
+++ b/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import { useVaultInformation } from 'hooks/useVaultInformation';
 import { Chain } from 'mobx/model/network/chain';
-import { goToProtocol } from '../utils';
+import { getGoToText } from '../utils';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -59,11 +59,15 @@ export const MobileStickyActionButtons = observer(({ vault, onDepositClick, onWi
               Deposit
             </VaultActionButton>
           ) : (
-            <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
-              <VaultActionButton variant="contained" fullWidth color="primary">
-                Go to {goToProtocol(vault.protocol?.toLowerCase())}
-              </VaultActionButton>
-            </Link>
+            <>
+              {strategy.depositLink && (
+                <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
+                  <VaultActionButton variant="contained" fullWidth color="primary">
+                    Go to {getGoToText(vault)}
+                  </VaultActionButton>
+                </Link>
+              )}
+            </>
           )}
         </Grid>
         {userHasDeposit && (

--- a/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
+++ b/src/components-v2/vault-detail/actions/MobileStickyActionButtons.tsx
@@ -44,28 +44,34 @@ export const MobileStickyActionButtons = observer(({ vault, onDepositClick, onWi
   const { network } = networkStore;
   const strategy = Chain.getChain(network).strategies[vault.vaultToken];
 
+  const DepositButton = () => (
+    <VaultActionButton
+      fullWidth
+      color="primary"
+      variant={canUserDeposit && userHasToken ? 'contained' : 'outlined'}
+      disabled={!userHasToken || !canUserDeposit}
+      onClick={onDepositClick}
+    >
+      Deposit
+    </VaultActionButton>
+  );
+
   return (
     <div className={classes.root}>
       <Grid container spacing={1}>
         <Grid item xs>
           {userHasToken ? (
-            <VaultActionButton
-              fullWidth
-              color="primary"
-              variant={canUserDeposit ? 'contained' : 'outlined'}
-              disabled={!canUserDeposit}
-              onClick={onDepositClick}
-            >
-              Deposit
-            </VaultActionButton>
+            <DepositButton />
           ) : (
             <>
-              {strategy.depositLink && (
+              {strategy?.depositLink ? (
                 <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
                   <VaultActionButton variant="contained" fullWidth color="primary">
                     Go to {getGoToText(vault)}
                   </VaultActionButton>
                 </Link>
+              ) : (
+                <DepositButton />
               )}
             </>
           )}

--- a/src/components-v2/vault-detail/holdings/Holdings.tsx
+++ b/src/components-v2/vault-detail/holdings/Holdings.tsx
@@ -5,6 +5,7 @@ import { Chain } from 'mobx/model/network/chain';
 import { StoreContext } from 'mobx/stores/store-context';
 import React from 'react';
 import { shouldDisplayEarnings } from 'utils/componentHelpers';
+
 import { numberWithCommas } from '../../../mobx/utils/helpers';
 import { HoldingItem } from './HoldingItem';
 import { HoldingsActionButtons } from './HoldingsActionButtons';

--- a/src/components-v2/vault-detail/holdings/Holdings.tsx
+++ b/src/components-v2/vault-detail/holdings/Holdings.tsx
@@ -37,18 +37,19 @@ export const Holdings = ({ userData, vault, onDepositClick, onWithdrawClick }: P
   const { user, chain: networkStore } = React.useContext(StoreContext);
   const { network } = networkStore;
   const strategy = Chain.getChain(network).strategies[vault.vaultToken];
-  const isUserHasToken = user.getBalance(vault.underlyingToken).hasBalance();
-  const isUserHasDeposit = !depositBalance.tokenBalance.eq(0);
+  const userHasToken = user.getBalance(vault.underlyingToken).hasBalance();
+  const userHasDeposit = !depositBalance.tokenBalance.eq(0);
 
-  if (!isUserHasDeposit) {
+  if (!userHasDeposit) {
     return (
       <Grid container>
         <NoHoldings
-          isUserHasDeposit={isUserHasDeposit}
+          userHasDeposit={userHasDeposit}
           strategy={strategy}
-          isUserHasToken={isUserHasToken}
+          userHasToken={userHasToken}
           vault={vault}
           onDepositClick={onDepositClick}
+          isMediumSizeScreen={isMediumSizeScreen}
         />
       </Grid>
     );
@@ -86,11 +87,11 @@ export const Holdings = ({ userData, vault, onDepositClick, onWithdrawClick }: P
           <Grid item xs={12} sm>
             <HoldingsActionButtons
               strategy={strategy}
-              isUserHasToken={isUserHasToken}
+              userHasToken={userHasToken}
               vault={vault}
               onDepositClick={onDepositClick}
               onWithdrawClick={onWithdrawClick}
-              isUserHasDeposit={isUserHasDeposit}
+              userHasDeposit={userHasDeposit}
             />
           </Grid>
         )}

--- a/src/components-v2/vault-detail/holdings/Holdings.tsx
+++ b/src/components-v2/vault-detail/holdings/Holdings.tsx
@@ -1,9 +1,10 @@
 import { VaultData, VaultDTOV3 } from '@badger-dao/sdk';
 import { Grid, makeStyles, Typography, useMediaQuery, useTheme } from '@material-ui/core';
 import { useVaultInformation } from 'hooks/useVaultInformation';
+import { Chain } from 'mobx/model/network/chain';
+import { StoreContext } from 'mobx/stores/store-context';
 import React from 'react';
 import { shouldDisplayEarnings } from 'utils/componentHelpers';
-
 import { numberWithCommas } from '../../../mobx/utils/helpers';
 import { HoldingItem } from './HoldingItem';
 import { HoldingsActionButtons } from './HoldingsActionButtons';
@@ -33,11 +34,22 @@ export const Holdings = ({ userData, vault, onDepositClick, onWithdrawClick }: P
   const isMediumSizeScreen = useMediaQuery(useTheme().breakpoints.up('sm'));
   const classes = useStyles();
   const { depositBalance } = useVaultInformation(vault);
+  const { user, chain: networkStore } = React.useContext(StoreContext);
+  const { network } = networkStore;
+  const strategy = Chain.getChain(network).strategies[vault.vaultToken];
+  const isUserHasToken = user.getBalance(vault.underlyingToken).hasBalance();
+  const isUserHasDeposit = !depositBalance.tokenBalance.eq(0);
 
-  if (depositBalance.tokenBalance.eq(0)) {
+  if (!isUserHasDeposit) {
     return (
       <Grid container>
-        <NoHoldings vault={vault} onDepositClick={onDepositClick} />
+        <NoHoldings
+          isUserHasDeposit={isUserHasDeposit}
+          strategy={strategy}
+          isUserHasToken={isUserHasToken}
+          vault={vault}
+          onDepositClick={onDepositClick}
+        />
       </Grid>
     );
   }
@@ -72,7 +84,14 @@ export const Holdings = ({ userData, vault, onDepositClick, onWithdrawClick }: P
         )}
         {isMediumSizeScreen && (
           <Grid item xs={12} sm>
-            <HoldingsActionButtons vault={vault} onDepositClick={onDepositClick} onWithdrawClick={onWithdrawClick} />
+            <HoldingsActionButtons
+              strategy={strategy}
+              isUserHasToken={isUserHasToken}
+              vault={vault}
+              onDepositClick={onDepositClick}
+              onWithdrawClick={onWithdrawClick}
+              isUserHasDeposit={isUserHasDeposit}
+            />
           </Grid>
         )}
       </Grid>

--- a/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
@@ -5,6 +5,7 @@ import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
 import { StoreContext } from 'mobx/stores/store-context';
 import React from 'react';
 import { VaultActionButton } from '../../common/VaultActionButtons';
+import { goToProtocol } from '../utils';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -64,7 +65,7 @@ export const HoldingsActionButtons = ({
           ) : (
             <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
               <VaultActionButton variant="contained" fullWidth color="primary">
-                Go to {vault.protocol}
+                Go to {goToProtocol(vault.protocol?.toLowerCase())}
               </VaultActionButton>
             </Link>
           )}

--- a/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
 import { StoreContext } from 'mobx/stores/store-context';
 import React from 'react';
+
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import { getGoToText } from '../utils';
 

--- a/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
@@ -28,18 +28,18 @@ interface Props {
   vault: VaultDTOV3;
   onDepositClick: () => void;
   onWithdrawClick: () => void;
-  isUserHasToken: boolean;
+  userHasToken: boolean;
   strategy: StrategyConfig;
-  isUserHasDeposit: boolean;
+  userHasDeposit: boolean;
 }
 
 export const HoldingsActionButtons = ({
   vault,
   onDepositClick,
   onWithdrawClick,
-  isUserHasToken,
+  userHasToken,
   strategy,
-  isUserHasDeposit,
+  userHasDeposit,
 }: Props): JSX.Element => {
   const { vaults, wallet } = React.useContext(StoreContext);
   const canUserDeposit = wallet.isConnected ? vaults.canUserDeposit(vault) : false;
@@ -48,9 +48,9 @@ export const HoldingsActionButtons = ({
 
   return (
     <div className={classes.root}>
-      {isUserHasDeposit && (
+      {userHasDeposit && (
         <>
-          {isUserHasToken ? (
+          {userHasToken ? (
             <VaultActionButton
               fullWidth
               className={classes.deposit}

--- a/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
@@ -5,7 +5,7 @@ import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
 import { StoreContext } from 'mobx/stores/store-context';
 import React from 'react';
 import { VaultActionButton } from '../../common/VaultActionButtons';
-import { goToProtocol } from '../utils';
+import { getGoToText } from '../utils';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -63,11 +63,15 @@ export const HoldingsActionButtons = ({
               Deposit
             </VaultActionButton>
           ) : (
-            <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
-              <VaultActionButton variant="contained" fullWidth color="primary">
-                Go to {goToProtocol(vault.protocol?.toLowerCase())}
-              </VaultActionButton>
-            </Link>
+            <>
+              {strategy.depositLink && (
+                <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
+                  <VaultActionButton variant="contained" fullWidth color="primary">
+                    Go to {getGoToText(vault)}
+                  </VaultActionButton>
+                </Link>
+              )}
+            </>
           )}
         </>
       )}

--- a/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
@@ -1,8 +1,9 @@
 import { VaultDTOV3 } from '@badger-dao/sdk';
+import { Link } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
 import { StoreContext } from 'mobx/stores/store-context';
 import React from 'react';
-
 import { VaultActionButton } from '../../common/VaultActionButtons';
 
 const useStyles = makeStyles((theme) => ({
@@ -18,15 +19,28 @@ const useStyles = makeStyles((theme) => ({
   withdraw: {
     marginTop: theme.spacing(2),
   },
+  goToLink: {
+    width: '100%',
+  },
 }));
 
 interface Props {
   vault: VaultDTOV3;
   onDepositClick: () => void;
   onWithdrawClick: () => void;
+  isUserHasToken: boolean;
+  strategy: StrategyConfig;
+  isUserHasDeposit: boolean;
 }
 
-export const HoldingsActionButtons = ({ vault, onDepositClick, onWithdrawClick }: Props): JSX.Element => {
+export const HoldingsActionButtons = ({
+  vault,
+  onDepositClick,
+  onWithdrawClick,
+  isUserHasToken,
+  strategy,
+  isUserHasDeposit,
+}: Props): JSX.Element => {
   const { vaults, wallet } = React.useContext(StoreContext);
   const canUserDeposit = wallet.isConnected ? vaults.canUserDeposit(vault) : false;
   const canUserWithdraw = vaults.canUserWithdraw(vault);
@@ -34,17 +48,27 @@ export const HoldingsActionButtons = ({ vault, onDepositClick, onWithdrawClick }
 
   return (
     <div className={classes.root}>
-      {canUserDeposit && (
-        <VaultActionButton
-          fullWidth
-          className={classes.deposit}
-          color="primary"
-          variant={canUserDeposit ? 'contained' : 'outlined'}
-          disabled={!canUserDeposit}
-          onClick={onDepositClick}
-        >
-          Deposit
-        </VaultActionButton>
+      {isUserHasDeposit && (
+        <>
+          {isUserHasToken ? (
+            <VaultActionButton
+              fullWidth
+              className={classes.deposit}
+              color="primary"
+              variant={canUserDeposit ? 'contained' : 'outlined'}
+              disabled={!canUserDeposit}
+              onClick={onDepositClick}
+            >
+              Deposit
+            </VaultActionButton>
+          ) : (
+            <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
+              <VaultActionButton variant="contained" fullWidth color="primary">
+                Go to {vault.protocol}
+              </VaultActionButton>
+            </Link>
+          )}
+        </>
       )}
       <VaultActionButton
         className={classes.withdraw}

--- a/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
+++ b/src/components-v2/vault-detail/holdings/HoldingsActionButtons.tsx
@@ -47,29 +47,35 @@ export const HoldingsActionButtons = ({
   const canUserWithdraw = vaults.canUserWithdraw(vault);
   const classes = useStyles();
 
+  const DepositButton = () => (
+    <VaultActionButton
+      fullWidth
+      className={classes.deposit}
+      color="primary"
+      variant={canUserDeposit && userHasToken ? 'contained' : 'outlined'}
+      disabled={!userHasToken || !canUserDeposit}
+      onClick={onDepositClick}
+    >
+      Deposit
+    </VaultActionButton>
+  );
+
   return (
     <div className={classes.root}>
       {userHasDeposit && (
         <>
           {userHasToken ? (
-            <VaultActionButton
-              fullWidth
-              className={classes.deposit}
-              color="primary"
-              variant={canUserDeposit ? 'contained' : 'outlined'}
-              disabled={!canUserDeposit}
-              onClick={onDepositClick}
-            >
-              Deposit
-            </VaultActionButton>
+            <DepositButton />
           ) : (
             <>
-              {strategy.depositLink && (
+              {strategy?.depositLink ? (
                 <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
                   <VaultActionButton variant="contained" fullWidth color="primary">
                     Go to {getGoToText(vault)}
                   </VaultActionButton>
                 </Link>
+              ) : (
+                <DepositButton />
               )}
             </>
           )}

--- a/src/components-v2/vault-detail/holdings/NoHoldings.tsx
+++ b/src/components-v2/vault-detail/holdings/NoHoldings.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import DepositInfo from './DepositInfo';
 import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
+import { goToProtocol } from '../utils';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -70,7 +71,7 @@ export const NoHoldings = observer(
             ) : (
               <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
                 <VaultActionButton variant="contained" fullWidth color="primary">
-                  Go to {vault.protocol}
+                  Go to {goToProtocol(vault.protocol?.toLowerCase())}
                 </VaultActionButton>
               </Link>
             )}

--- a/src/components-v2/vault-detail/holdings/NoHoldings.tsx
+++ b/src/components-v2/vault-detail/holdings/NoHoldings.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import DepositInfo from './DepositInfo';
 import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
-import { goToProtocol } from '../utils';
+import { getGoToText } from '../utils';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -69,11 +69,15 @@ export const NoHoldings = observer(
                 Deposit
               </VaultActionButton>
             ) : (
-              <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
-                <VaultActionButton variant="contained" fullWidth color="primary">
-                  Go to {goToProtocol(vault.protocol?.toLowerCase())}
-                </VaultActionButton>
-              </Link>
+              <>
+                {strategy.depositLink && (
+                  <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
+                    <VaultActionButton variant="contained" fullWidth color="primary">
+                      Go to {getGoToText(vault)}
+                    </VaultActionButton>
+                  </Link>
+                )}
+              </>
             )}
           </Grid>
         )}

--- a/src/components-v2/vault-detail/holdings/NoHoldings.tsx
+++ b/src/components-v2/vault-detail/holdings/NoHoldings.tsx
@@ -1,20 +1,16 @@
 import { VaultDTOV3 } from '@badger-dao/sdk';
-import { Grid, Paper, Typography } from '@material-ui/core';
+import { Grid, Link, Paper, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import { Chain } from 'mobx/model/network/chain';
 import { StoreContext } from 'mobx/stores/store-context';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
-
 import { VaultActionButton } from '../../common/VaultActionButtons';
 import DepositInfo from './DepositInfo';
+import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
 
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: theme.spacing(4),
-  },
-  description: {
-    marginTop: theme.spacing(1),
   },
   depositContainer: {
     display: 'flex',
@@ -27,35 +23,50 @@ const useStyles = makeStyles((theme) => ({
       justifyContent: 'center',
     },
   },
+  goToLink: {
+    width: '100%',
+  },
 }));
 
 interface Props {
   vault: VaultDTOV3;
   onDepositClick: () => void;
+  isUserHasToken: boolean;
+  strategy: StrategyConfig;
+  isUserHasDeposit: boolean;
 }
 
-export const NoHoldings = observer(({ vault, onDepositClick }: Props): JSX.Element | null => {
-  const store = React.useContext(StoreContext);
-  const { chain: networkStore, user } = store;
-  const { network } = networkStore;
-  const classes = useStyles();
+export const NoHoldings = observer(
+  ({ vault, onDepositClick, isUserHasToken, strategy, isUserHasDeposit }: Props): JSX.Element | null => {
+    const classes = useStyles();
 
-  if (!user.onGuestList(vault)) {
-    return null;
-  }
+    const store = React.useContext(StoreContext);
+    const { user } = store;
 
-  const strategy = Chain.getChain(network).strategies[vault.vaultToken];
-  return (
-    <Grid container className={classes.root} component={Paper}>
-      <Grid item xs={12} sm={8}>
-        <Typography variant="body1">{`You have no ${vault.name} in your connected wallet.`}</Typography>
-        <DepositInfo strategy={strategy} />
+    if (!user.onGuestList(vault)) {
+      return null;
+    }
+
+    return (
+      <Grid container className={classes.root} component={Paper}>
+        <Grid item xs={12} sm={8}>
+          <Typography variant="body1">{`You have no ${vault.name} in your connected wallet.`}</Typography>
+          <DepositInfo strategy={strategy} />
+        </Grid>
+        <Grid item xs={12} sm className={classes.depositContainer}>
+          {isUserHasToken ? (
+            <VaultActionButton color="primary" variant="contained" fullWidth onClick={onDepositClick}>
+              Deposit
+            </VaultActionButton>
+          ) : (
+            <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
+              <VaultActionButton variant="contained" fullWidth color="primary">
+                Go to {vault.protocol}
+              </VaultActionButton>
+            </Link>
+          )}
+        </Grid>
       </Grid>
-      <Grid item xs={12} sm className={classes.depositContainer}>
-        <VaultActionButton color="primary" variant="contained" fullWidth onClick={onDepositClick}>
-          Deposit
-        </VaultActionButton>
-      </Grid>
-    </Grid>
-  );
-});
+    );
+  },
+);

--- a/src/components-v2/vault-detail/holdings/NoHoldings.tsx
+++ b/src/components-v2/vault-detail/holdings/NoHoldings.tsx
@@ -31,13 +31,21 @@ const useStyles = makeStyles((theme) => ({
 interface Props {
   vault: VaultDTOV3;
   onDepositClick: () => void;
-  isUserHasToken: boolean;
+  userHasToken: boolean;
   strategy: StrategyConfig;
-  isUserHasDeposit: boolean;
+  userHasDeposit: boolean;
+  isMediumSizeScreen: boolean;
 }
 
 export const NoHoldings = observer(
-  ({ vault, onDepositClick, isUserHasToken, strategy, isUserHasDeposit }: Props): JSX.Element | null => {
+  ({
+    vault,
+    onDepositClick,
+    userHasToken,
+    strategy,
+    userHasDeposit,
+    isMediumSizeScreen,
+  }: Props): JSX.Element | null => {
     const classes = useStyles();
 
     const store = React.useContext(StoreContext);
@@ -53,19 +61,21 @@ export const NoHoldings = observer(
           <Typography variant="body1">{`You have no ${vault.name} in your connected wallet.`}</Typography>
           <DepositInfo strategy={strategy} />
         </Grid>
-        <Grid item xs={12} sm className={classes.depositContainer}>
-          {isUserHasToken ? (
-            <VaultActionButton color="primary" variant="contained" fullWidth onClick={onDepositClick}>
-              Deposit
-            </VaultActionButton>
-          ) : (
-            <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
-              <VaultActionButton variant="contained" fullWidth color="primary">
-                Go to {vault.protocol}
+        {isMediumSizeScreen && (
+          <Grid item xs={12} sm className={classes.depositContainer}>
+            {userHasToken ? (
+              <VaultActionButton color="primary" variant="contained" fullWidth onClick={onDepositClick}>
+                Deposit
               </VaultActionButton>
-            </Link>
-          )}
-        </Grid>
+            ) : (
+              <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
+                <VaultActionButton variant="contained" fullWidth color="primary">
+                  Go to {vault.protocol}
+                </VaultActionButton>
+              </Link>
+            )}
+          </Grid>
+        )}
       </Grid>
     );
   },

--- a/src/components-v2/vault-detail/holdings/NoHoldings.tsx
+++ b/src/components-v2/vault-detail/holdings/NoHoldings.tsx
@@ -1,13 +1,14 @@
 import { VaultDTOV3 } from '@badger-dao/sdk';
 import { Grid, Link, Paper, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
 import { StoreContext } from 'mobx/stores/store-context';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
+
 import { VaultActionButton } from '../../common/VaultActionButtons';
-import DepositInfo from './DepositInfo';
-import { StrategyConfig } from 'mobx/model/strategies/strategy-config';
 import { getGoToText } from '../utils';
+import DepositInfo from './DepositInfo';
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/src/components-v2/vault-detail/holdings/NoHoldings.tsx
+++ b/src/components-v2/vault-detail/holdings/NoHoldings.tsx
@@ -56,6 +56,18 @@ export const NoHoldings = observer(
       return null;
     }
 
+    const DepositButton = () => (
+      <VaultActionButton
+        color="primary"
+        variant={userHasToken ? 'contained' : 'outlined'}
+        fullWidth
+        onClick={onDepositClick}
+        disabled={!userHasToken}
+      >
+        Deposit
+      </VaultActionButton>
+    );
+
     return (
       <Grid container className={classes.root} component={Paper}>
         <Grid item xs={12} sm={8}>
@@ -65,17 +77,17 @@ export const NoHoldings = observer(
         {isMediumSizeScreen && (
           <Grid item xs={12} sm className={classes.depositContainer}>
             {userHasToken ? (
-              <VaultActionButton color="primary" variant="contained" fullWidth onClick={onDepositClick}>
-                Deposit
-              </VaultActionButton>
+              <DepositButton />
             ) : (
               <>
-                {strategy.depositLink && (
+                {strategy?.depositLink ? (
                   <Link href={strategy.depositLink} target="_blank" className={classes.goToLink} underline="none">
                     <VaultActionButton variant="contained" fullWidth color="primary">
                       Go to {getGoToText(vault)}
                     </VaultActionButton>
                   </Link>
+                ) : (
+                  <DepositButton />
                 )}
               </>
             )}

--- a/src/components-v2/vault-detail/utils.ts
+++ b/src/components-v2/vault-detail/utils.ts
@@ -48,3 +48,14 @@ export function defaultVaultBalance(vault: VaultDTOV3): VaultData {
     earnedTokens: [],
   };
 }
+
+export function goToProtocol(protocol: string): string {
+  switch (protocol) {
+    case 'aura':
+      return 'Balancer';
+    case 'convex':
+      return 'Curve';
+    default:
+      return protocol;
+  }
+}

--- a/src/components-v2/vault-detail/utils.ts
+++ b/src/components-v2/vault-detail/utils.ts
@@ -49,12 +49,24 @@ export function defaultVaultBalance(vault: VaultDTOV3): VaultData {
   };
 }
 
+export function getGoToText(vault: VaultDTOV3): string {
+  return goToProtocol(
+    ['aurabal', 'cvxcrv'].includes(vault.asset?.toLowerCase())
+      ? vault.asset?.toLowerCase()
+      : vault.protocol?.toLowerCase(),
+  );
+}
+
 export function goToProtocol(protocol: string): string {
   switch (protocol) {
     case 'aura':
       return 'Balancer';
     case 'convex':
       return 'Curve';
+    case 'aurabal':
+      return 'Aura';
+    case 'cvxcrv':
+      return 'Convex';
     default:
       return protocol;
   }

--- a/src/config/system/strategies.ts
+++ b/src/config/system/strategies.ts
@@ -286,7 +286,7 @@ export const getStrategies = (network: Network): StrategyNetworkConfig => {
         [ethDeploy.sett_system.vaults['native.cvxCrv']]: {
           strategyLink: 'https://badger.wiki/strategies#51d48102bc4847a6a5a1a059c4b827b3',
           userGuide: 'https://docs.badger.com/badger-finance/setts/sett-user-guides-ethereum/cvxcrv-helper',
-          depositLink: 'https://www.convexfinance.com/stake'
+          depositLink: 'https://www.convexfinance.com/stake',
         },
         [ethDeploy.sett_system.vaults['native.cvx']]: {
           strategyLink: 'https://badger.wiki/strategies#1346adfaad7946eebd29a17fb4f6e8b7',
@@ -325,7 +325,7 @@ export const getStrategies = (network: Network): StrategyNetworkConfig => {
         },
         [ethDeploy.sett_system.vaults['native.auraBal']]: {
           userGuide: 'https://docs.badger.com/badger-finance/vaults/vault-user-guides-ethereum/aurabal-helper',
-          depositLink: 'https://app.aura.finance/'
+          depositLink: 'https://app.aura.finance/',
         },
         [ethDeploy.sett_system.vaults['native.aura-wbtc-badger']]: {
           userGuide: 'https://docs.badger.com/badger-finance/vaults/vault-user-guides-ethereum/b20wbtc-80badger',

--- a/src/config/system/strategies.ts
+++ b/src/config/system/strategies.ts
@@ -286,6 +286,7 @@ export const getStrategies = (network: Network): StrategyNetworkConfig => {
         [ethDeploy.sett_system.vaults['native.cvxCrv']]: {
           strategyLink: 'https://badger.wiki/strategies#51d48102bc4847a6a5a1a059c4b827b3',
           userGuide: 'https://docs.badger.com/badger-finance/setts/sett-user-guides-ethereum/cvxcrv-helper',
+          depositLink: 'https://www.convexfinance.com/stake'
         },
         [ethDeploy.sett_system.vaults['native.cvx']]: {
           strategyLink: 'https://badger.wiki/strategies#1346adfaad7946eebd29a17fb4f6e8b7',
@@ -324,6 +325,7 @@ export const getStrategies = (network: Network): StrategyNetworkConfig => {
         },
         [ethDeploy.sett_system.vaults['native.auraBal']]: {
           userGuide: 'https://docs.badger.com/badger-finance/vaults/vault-user-guides-ethereum/aurabal-helper',
+          depositLink: 'https://app.aura.finance/'
         },
         [ethDeploy.sett_system.vaults['native.aura-wbtc-badger']]: {
           userGuide: 'https://docs.badger.com/badger-finance/vaults/vault-user-guides-ethereum/b20wbtc-80badger',


### PR DESCRIPTION
  Note: For a few vaults, there is no `depositLink` in file strategies.ts

||
|---|
|No Deposit Token|
|<img width="1193" alt="Screenshot 2022-09-15 at 10 37 29 PM" src="https://user-images.githubusercontent.com/4344538/190467286-ce5d571b-d3a5-42e1-a5c0-6b41e475f69f.png">|
|Convex protocol|
|<img width="1183" alt="Screenshot 2022-09-12 at 9 41 18 PM" src="https://user-images.githubusercontent.com/4344538/189703803-1f350eca-4420-4bce-bfb3-f3dd658e206e.png">|
|Aura protocol|
|<img width="1169" alt="Screenshot 2022-09-12 at 9 43 03 PM" src="https://user-images.githubusercontent.com/4344538/189704005-df16f5cf-cb3c-46ce-ab25-56918fb03ec8.png">|
|cvxCRV|
|<img width="1185" alt="Screenshot 2022-09-13 at 4 51 12 PM" src="https://user-images.githubusercontent.com/4344538/189888644-82914a9d-412f-46cd-8e71-d94d9b7e7ee5.png">|
|auraBAL|
|<img width="1173" alt="Screenshot 2022-09-13 at 4 50 59 PM" src="https://user-images.githubusercontent.com/4344538/189888880-919ce64c-5b96-4460-8cfc-871c609dc3b1.png">|
|Mobile|
|<img width="393" alt="Screenshot 2022-09-12 at 9 44 00 PM" src="https://user-images.githubusercontent.com/4344538/189704195-447bd87d-ccc2-4f5a-8f53-190044060519.png">|




