### PR TITLE
[ISSUE 2403] |  Misaligned text on rewards guide

### DIFF
--- a/src/components-v2/rewards/UserGuideContent.tsx
+++ b/src/components-v2/rewards/UserGuideContent.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: '21px 22px',
       borderRadius: 10,
       width: 219,
-      height: 144,
+      minHeight: 144,
     },
     rewardsOptions: {
       paddingInlineStart: theme.spacing(2),


### PR DESCRIPTION
<img width="735" alt="Screenshot 2022-09-30 at 11 09 11 PM" src="https://user-images.githubusercontent.com/4344538/193326218-ad58581f-2832-46fe-ae74-f36eec1d9f36.png">
